### PR TITLE
fix: compatibility with 5.1 kernel

### DIFF
--- a/kernelmod/vfs_utils.c
+++ b/kernelmod/vfs_utils.c
@@ -24,7 +24,7 @@ char* __init read_file_content(const char* filename, int *real_size)
 		return 0;
 	}
 	mm_segment_t old_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 	// i_size_read is useless here because procfs does not have i_size
 	// loff_t size = i_size_read(file_inode(filp));


### PR DESCRIPTION
get_ds was defined as KERNEL_DS since 2.6. It was removed in 5.1.

https://github.com/torvalds/linux/commit/736706bee3298208343a76096370e4f6a5c55915