### PR TITLE
fix: 解决init_vfs_changes申请连续大内存失败的问题

### DIFF
--- a/kernelmod/vfs_change.c
+++ b/kernelmod/vfs_change.c
@@ -376,15 +376,15 @@ static struct proc_ops procfs_ops = {
 #endif
 int __init init_vfs_changes(void)
 {
-	vfs_changes_buf = kmalloc(MAX_VFS_CHANGE_MEM, GFP_KERNEL);
+	vfs_changes_buf = vmalloc(MAX_VFS_CHANGE_MEM);
 	if (!vfs_changes_buf) {
-		pr_warn("init_vfs_changes kmalloc fail\n", PROCFS_NAME);
+		pr_warn("init_vfs_changes vmalloc fail\n", PROCFS_NAME);
 		return -ENOMEM;
 	}
 
 	struct proc_dir_entry* procfs_entry = proc_create(PROCFS_NAME, 0666, 0, &procfs_ops);
 	if (procfs_entry == 0) {
-		kfree(vfs_changes_buf);
+		vfree(vfs_changes_buf);
 		vfs_changes_buf = NULL;
 		pr_warn("%s already exists?\n", PROCFS_NAME);
 		return -1;
@@ -411,7 +411,7 @@ void cleanup_vfs_changes(void)
 	spin_unlock(&sl_changes);
 
 	if (vfs_changes_buf) {
-		kfree(vfs_changes_buf);
+		vfree(vfs_changes_buf);
 		vfs_changes_buf = NULL;
 	}
 }


### PR DESCRIPTION
当加载vfs_monitor模块时函数init_vfs_changes会申请1MiB连续内存,
系统如果长时间不关机并且反复挂起、唤醒系统,那么deepin-anything-monitor.service服务会反复停止、启动,
导致反复加载、卸载vfs_monitor模块,由于系统长时间运行可能没有连续的1Mib内存,所以会导致申请内存失败,模块加载失败。

Signed-off-by: zhanglianjie <zhanglianjie@uniontech.com>