### PR TITLE
chore: remove dh-systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-anything
 Section: admin
 Priority: optional
 Maintainer: Deepin Package Builder <packages@deepin.com>
-Build-Depends: debhelper (>= 9), dkms, dh-systemd, qtbase5-dev,
+Build-Depends: debhelper (>= 9), dkms, qtbase5-dev,
  pkg-config, libudisks2-qt5-dev, libmount-dev, libdtkcore-dev, libglib2.0-dev
 Standards-Version: 3.9.8
 Homepage: http://github.com/linuxdeepin/deepin-anything

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export QT_SELECT=5
 
 %:
-	dh $@ --with dkms,systemd
+	dh $@ --with dkms
 
 override_dh_installinit:
 	true


### PR DESCRIPTION
移除 [dh-systemd](https://packages.debian.org/sid/dh-systemd) 依赖

> ### debhelper add-on to handle systemd unit files - transitional package
> This package is for transitional purposes and can be removed safely.

是处理 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。

其它相关：https://github.com/linuxdeepin/dde-file-manager/pull/488