### PR TITLE
fix: search for new files failed due to using wrong mount point

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Deepin Package Builder <packages@deepin.com>
 Build-Depends: debhelper (>= 9), dkms, qtbase5-dev,
- pkg-config, libudisks2-qt5-dev, libmount-dev, libdtkcore-dev, libglib2.0-dev
+ pkg-config, libudisks2-qt5-dev, libmount-dev, libdtkcore-dev, libglib2.0-dev, libpcre3-dev
 Standards-Version: 3.9.8
 Homepage: http://github.com/linuxdeepin/deepin-anything
 

--- a/server/backend/lib/lftdisktool.cpp
+++ b/server/backend/lib/lftdisktool.cpp
@@ -131,8 +131,12 @@ QByteArrayList fromSerialUri(const QByteArray &uri)
                     new_path = path.mid(info.sourcePath.size());
                 }
 
-                // 因为挂载点是以 '\0' 结尾的, 所以此处必须要分开转成QString;
-                pathList << mount_point.append(new_path);
+                if (new_path.isEmpty()) {
+                    pathList << mount_point;
+                } else {
+                    mount_point.append("/");
+                    pathList << mount_point.append(new_path);
+                }
             }
 
             return pathList;


### PR DESCRIPTION
When deepin-anything-tool builds the index, it will use the first mount point of the block device instead of the root mount point. Under certain conditions, it is impossible to use the file event to update the index. The solution is to use the root mount point of the block device when deepin-anything-tool builds the index.

Log: Adapt to V23
Bug: https://pms.uniontech.com/bug-view-144735.html