### PR TITLE
fix: crash when search for invalid regex

### DIFF
--- a/library/src/fs_buf.c
+++ b/library/src/fs_buf.c
@@ -1416,6 +1416,8 @@ __attribute__((visibility("default"))) void parallelsearch_files(fs_buf *fsbuf, 
 		const char *error;
 		int erroffset;
 		regex = pcre_compile(query, PCRE_CASELESS, &error, &erroffset, NULL);
+	}
+	if (regex) {
 		comquery->query = (void*)regex;
 	} else {
 		comquery->query = (void*)query;


### PR DESCRIPTION
The crash when searching for invalid regular expressions is caused by an inconsistency in deepin-anything-tool's internal logic for checking regular expressions. The solution is to change the check logic to be consistent.

Log: fix bug