### PR TITLE
fix: a dbus security issue

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+getent group deepin-anything >/dev/null || /usr/sbin/groupadd --system deepin-anything
+getent passwd deepin-anything >/dev/null || /usr/sbin/useradd --system -c "deepin-anything User" \
+        -d /var/lib/deepin-anything -m -g deepin-anything -s /usr/sbin/nologin \
+        -G deepin-anything deepin-anything

--- a/src/server/backend/dbusservice/com.deepin.anything.conf
+++ b/src/server/backend/dbusservice/com.deepin.anything.conf
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
 
-  <!-- Only root can own the service -->
-  <policy user="root">
+  <!-- everybody is allowed to own the service on the D-Bus system bus -->
+  <policy user="deepin-anything">
     <allow own="com.deepin.anything"/>
   </policy>
 


### PR DESCRIPTION
fix: a dbus security issue (https://github.com/linuxdeepin/developer-center/issues/3526)

everybody is allowed to own the service on the D-Bus system bus.

Log: fix boo#1136026, https://github.com/linuxdeepin/developer-center/issues/3526