### PR TITLE
chore: adjust logging

### DIFF
--- a/src/server/backend/backend.pro
+++ b/src/server/backend/backend.pro
@@ -42,8 +42,10 @@ CONFIG(debug, debug|release) {
     LIBS += -L$$_PRO_FILE_PWD_/../../library/bin/debug -lanything -lnl-genl-3 -lnl-3
     DEPENDPATH += $$_PRO_FILE_PWD_/../../library/bin/debug
     unix:QMAKE_RPATHDIR += $$_PRO_FILE_PWD_/../../library/bin/debug
+    DEFINES += DEFAULT_MSG_TYPE=QtDebugMsg
 } else {
     LIBS += -L$$_PRO_FILE_PWD_/../../library/bin/release -lanything -lnl-genl-3 -lnl-3
+    DEFINES += DEFAULT_MSG_TYPE=QtWarningMsg
 }
 
 isEmpty(LIB_INSTALL_DIR) {

--- a/src/server/backend/eventsource_genl.h
+++ b/src/server/backend/eventsource_genl.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +22,8 @@ class EventSource_GENL : public EventSource
 public:
     EventSource_GENL();
     ~EventSource_GENL() override;
+
+    static QStringList logCategoryList();
 
     bool init() override;
     bool isInited() override;

--- a/src/server/backend/lib/daspluginloader.h
+++ b/src/server/backend/lib/daspluginloader.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +23,8 @@ public:
                              Qt::CaseSensitivity = Qt::CaseSensitive,
                              bool repetitiveKeyInsensitive  = false);
     ~DASPluginLoader();
+
+    static QStringList logCategoryList();
 
     QList<QJsonObject> metaData() const;
     QObject *instance(int index) const;

--- a/src/server/backend/lib/lftdisktool.cpp
+++ b/src/server/backend/lib/lftdisktool.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,13 +11,26 @@
 #include <QStorageInfo>
 #include <QScopedPointer>
 #include <QDebug>
+#include <QLoggingCategory>
 
 extern "C" {
 #include <libmount.h>
 }
 
+Q_LOGGING_CATEGORY(lcDiskTool, "anything.manager.disktool", DEFAULT_MSG_TYPE)
+#define diskToolWarning(...) qCWarning(lcDiskTool, __VA_ARGS__)
+
 namespace LFTDiskTool {
 Q_GLOBAL_STATIC(DDiskManager, _global_diskManager)
+
+QStringList logCategoryList()
+{
+    QStringList list;
+
+    list << lcDiskTool().categoryName();
+
+    return list;
+}
 
 QByteArray pathToSerialUri(const QString &path)
 {
@@ -139,7 +152,7 @@ static int parser_errcb(libmnt_table *tb, const char *filename, int line)
 {
     Q_UNUSED(tb)
 
-    qWarning("%s: parse error at line %d -- ignored", filename, line);
+    diskToolWarning("%s: parse error at line %d -- ignored", filename, line);
 
     return 1;
 }
@@ -177,7 +190,7 @@ QMap<QByteArray, MountPointInfo> getMountPointsInfos(const QByteArrayList &mount
     int rc = mnt_table_parse_mtab(tb.data(), "/proc/self/mountinfo");
 
     if (rc) {
-        qWarning("can't read /proc/self/mountinfo");
+        diskToolWarning("can't read /proc/self/mountinfo");
 
         return map;
     }
@@ -193,7 +206,7 @@ QMap<QByteArray, MountPointInfo> getMountPointsInfos(const QByteArrayList &mount
 
             map[mount_point] = info;
         } else {
-            qWarning("can't find mountpoint \"%s\"", mount_point.constData());
+            diskToolWarning("can't find mountpoint \"%s\"", mount_point.constData());
         }
     }
 

--- a/src/server/backend/lib/lftdisktool.h
+++ b/src/server/backend/lib/lftdisktool.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,8 @@ struct MountPointInfo {
     QByteArray sourceDevice;
     QByteArray sourcePath;
 };
+
+QStringList logCategoryList();
 
 QMap<QByteArray, MountPointInfo> getMountPointsInfos(const QByteArrayList &mountPointList);
 

--- a/src/server/backend/lib/lftmanager.cpp
+++ b/src/server/backend/lib/lftmanager.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,8 +25,8 @@ extern "C" {
 #include <unistd.h>
 #include <sys/time.h>
 
-Q_GLOBAL_STATIC_WITH_ARGS(QLoggingCategory, normalLog, ("manager.normal"))
-Q_GLOBAL_STATIC_WITH_ARGS(QLoggingCategory, changesLog, ("manager.changes", QtWarningMsg))
+Q_GLOBAL_STATIC_WITH_ARGS(QLoggingCategory, normalLog, ("anything.manager.normal", DEFAULT_MSG_TYPE))
+Q_GLOBAL_STATIC_WITH_ARGS(QLoggingCategory, changesLog, ("anything.manager.changes", DEFAULT_MSG_TYPE))
 
 #define nDebug(...) qCDebug((*normalLog), __VA_ARGS__)
 #define nInfo(...) qCInfo((*normalLog), __VA_ARGS__)
@@ -156,7 +156,7 @@ QStringList LFTManager::logCategoryList()
     list << normalLog->categoryName()
          << changesLog->categoryName();
 
-    return list;
+    return list + LFTDiskTool::logCategoryList();
 }
 
 QByteArray LFTManager::setCodecNameForLocale(const QByteArray &codecName)
@@ -540,7 +540,7 @@ bool LFTManager::cancelBuild(const QString &path)
 
         // 清理其它等价的路径
         for (const QString &path : _global_fsWatcherMap->keys(watcher)) {
-            qDebug() << "do remove:" << path;
+            nDebug() << "do remove:" << path;
 
             _global_fsWatcherMap->remove(path);
         }
@@ -987,7 +987,7 @@ void LFTManager::setAutoIndexInternal(bool autoIndexInternal)
 
 void LFTManager::setLogLevel(int logLevel)
 {
-    qDebug() << logLevel;
+    nDebug() << "setLogLevel:" << logLevel;
 
     normalLog->setEnabled(QtDebugMsg, logLevel > 0);
     normalLog->setEnabled(QtWarningMsg, logLevel > 0);

--- a/src/server/backend/server.cpp
+++ b/src/server/backend/server.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,14 +20,24 @@ DAS_BEGIN_NAMESPACE
 
 static const char* act_names[] = {"file_created", "link_created", "symlink_created", "dir_created", "file_deleted", "dir_deleted", "file_renamed", "dir_renamed"};
 
-Q_LOGGING_CATEGORY(server, "server", QtInfoMsg)
-#define serverInfo(...) qCInfo(server, __VA_ARGS__)
+Q_LOGGING_CATEGORY(lcServer, "anything.monitor.server", DEFAULT_MSG_TYPE)
+#define serverWarning(...) qCWarning(lcServer, __VA_ARGS__)
+#define serverDebug(...) qCDebug(lcServer, __VA_ARGS__)
 
 Server::Server(EventSource *eventsrc, QObject *parent)
     : QThread(parent)
     , eventsrc(eventsrc)
 {
     qRegisterMetaType<QList<QPair<QByteArray, QByteArray>>>();
+}
+
+QStringList Server::logCategoryList()
+{
+    QStringList list;
+
+    list << lcServer().categoryName();
+
+    return list;
 }
 
 void Server::run()
@@ -47,7 +57,7 @@ void Server::run()
             case ACT_NEW_SYMLINK:
             case ACT_NEW_LINK:
             case ACT_NEW_FOLDER:
-                // serverInfo("%s: %s", act_names[action], src);
+                serverDebug("%s: %s", act_names[action], src);
 
                 create_list << src;
 
@@ -62,7 +72,7 @@ void Server::run()
                 break;
             case ACT_DEL_FILE:
             case ACT_DEL_FOLDER:
-                // serverInfo("%s: %s", act_names[action], src);
+                serverDebug("%s: %s", act_names[action], src);
 
                 delete_list << src;
 
@@ -77,7 +87,7 @@ void Server::run()
                 break;
             case ACT_RENAME_FILE:
             case ACT_RENAME_FOLDER:
-                // serverInfo("%s: %s, %s", act_names[action], src, dst);
+                serverDebug("%s: %s, %s", act_names[action], src, dst);
 
                 rename_list << qMakePair(QByteArray(src), QByteArray(dst));
 
@@ -91,7 +101,7 @@ void Server::run()
 
                 break;
             default:
-                qWarning() << "Unknow file action" << int(action);
+                serverWarning("Unknow file action: %d", int(action));
                 break;
             }
 

--- a/src/server/backend/server.h
+++ b/src/server/backend/server.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,8 @@ class Server : public QThread
 
 public:
     explicit Server(EventSource *eventsrc, QObject *parent = nullptr);
+
+    static QStringList logCategoryList();
 
 signals:
     void fileCreated(QByteArrayList files);


### PR DESCRIPTION
Adjust the level of some log content. Set the default log output level, the release version is warning, and the debug version is debug. All logs use category logs, and adjust the category name, no longer use global logs and register corresponding appenders.

log: adjust logging