### PR TITLE
fix: [mod]Fix dkms build error on some platform.

### DIFF
--- a/src/kernelmod/event_merge.c
+++ b/src/kernelmod/event_merge.c
@@ -7,6 +7,7 @@
 #include <linux/jiffies.h>
 #include <linux/version.h>
 #include <linux/delay.h>
+#include <linux/string.h>
 
 #include "event_merge.h"
 #include "event.h"


### PR DESCRIPTION
There is "-Werror=implicit-function-declaration" issue for strcmp function on SW platform, include the miss header file to fix it.

Log: fix dkms build issue.