### PR TITLE
fix: fix miss libcgroup depending.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (6.0.9) unstable; urgency=medium
+
+  * fix miss libcgroup depending.
+
+ -- Deepin Package Builder <packages@deepin.com>  Wed, 31 May 2023 16:30:58 +0800
+
 deepin-anything (6.0.8) unstable; urgency=medium
 
   * add cpu resource usage limit.

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -2,7 +2,7 @@ CC := gcc
 GLIB_INCL := $(shell pkg-config --cflags glib-2.0)
 GLIB_LIB := $(shell pkg-config --libs glib-2.0)
 CFLAGS := -std=gnu99 -Wall -Wl,--no-undefined -D_GNU_SOURCE -Iinc -Iinc/index -I../../3rdparty/fsearch ${GLIB_INCL} -shared -fPIC -fvisibility=hidden
-LDFLAG := -lpthread -lpcre ${GLIB_LIB} -lcgroup
+LDFLAG := -lpthread -lpcre ${GLIB_LIB}
 
 all: release debug
 

--- a/src/library/inc/resourceutil .h
+++ b/src/library/inc/resourceutil .h
@@ -5,11 +5,16 @@
 #pragma once
 
 #include <stdint.h>
+#ifdef ENABLE_CGROUP
+#include <libcgroup.h>
+#endif
 
 // get this pid cpu usage percent
 double get_pid_cpupercent(int pid);
 
+#ifdef ENABLE_CGROUP
 // taskpid = 0, means self task pid; 
 // percent = cpu.cfs_quota_us/cpu.cfs_period_us
 int limit_cpu(int taskpid, int percent, struct cgroup **cg_ret);
 int free_cg_cpu(struct cgroup *cg);
+#endif

--- a/src/library/src/resourceutil.c
+++ b/src/library/src/resourceutil.c
@@ -5,15 +5,19 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <libcgroup.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <sched.h>
 #include <time.h>
+#include <bits/time.h>
 #include <inttypes.h>
 
 #include "utils.h"
 #include "resourceutil .h"
 
-#define IO_BLK_SIZE (1 << 14)
+#ifdef ENABLE_CGROUP
 #define CGROUP_NAME "dfmgroup"
+#endif
 
 #ifdef CLOCK_MONOTONIC_RAW
 #define CPU_USAGE_CLOCK CLOCK_MONOTONIC_RAW
@@ -98,6 +102,7 @@ __attribute__((visibility("default"))) double get_pid_cpupercent(int pid)
 	return cpu_percent;
 }
 
+#ifdef ENABLE_CGROUP
 __attribute__((visibility("default"))) int limit_cpu(int taskpid, int percent, struct cgroup **cg_ret)
 {
 	if (percent < 0 || percent > 100) {
@@ -196,3 +201,4 @@ __attribute__((visibility("default"))) int free_cg_cpu(struct cgroup *cg)
 	cgroup_free(&cg);
 	return 0;
 }
+#endif


### PR DESCRIPTION
Currectly, the cgroup limit has not been used, use macro exclude it.

Log: fix build issue.