### PR TITLE
fix: Fix can not get dir_name on loongson64.

### DIFF
--- a/src/kernelmod/arg_extractor.c
+++ b/src/kernelmod/arg_extractor.c
@@ -27,7 +27,7 @@ unsigned long get_arg(struct pt_regs* regs, int n)
 		case 5: return regs->r8;
 		case 6: return regs->r9;
 
-#elif defined(CONFIG_CPU_LOONGSON3)
+#elif defined(CONFIG_CPU_LOONGSON3) || defined(CONFIG_CPU_LOONGSON64)
 
 		case 1:  // a0
 		case 2:  // a1


### PR DESCRIPTION
Since the 3A5000, kernel CPU config changed to LOONGSON64, the reg is same as loongson3.

Log: fix loongson64.