### PR TITLE
fix dkms install failed issue. 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-anything (6.1.0) unstable; urgency=medium
+
+  * fix dkms install issue.
+  * fix dir name is 0 on loongson64.
+  * fix BUG warning issue.
+
+ -- Deepin Package Builder <packages@deepin.com>  Wed, 07 Jun 2023 17:30:58 +0800
+
 deepin-anything (6.0.9) unstable; urgency=medium
 
   * fix miss libcgroup depending.

--- a/debian/deepin-anything-dkms.postinst
+++ b/debian/deepin-anything-dkms.postinst
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+action="$1"
+
+PKG_NAME="deepin-anything"
+CONF="usr/lib/modules-load.d/anything.conf"
+
+# // get current pkgage install status.
+output=$(sudo dkms status $PKG_NAME | awk '{gsub(/:/,"",$2); print $2, $3}')
+read version status <<< "$output"
+
+VAR_PATH="/var/lib/dkms/$PKG_NAME/$version"
+
+# // it has been added, but fail to install by some reasons.
+if [ "$status" = added ]; then
+    echo "previous deb install failed, remove dkms source: $VAR_PATH"
+
+    if [ "$action" = configure ]; then
+        # clean dkms sources if exist
+        if [ -d $VAR_PATH ]; then
+            rm -r $VAR_PATH
+        fi
+        if [ -f $CONF ]; then
+            rm $CONF
+        fi
+    fi
+fi
+
+#DEBHELPER#

--- a/src/kernelmod/arg_extractor.c
+++ b/src/kernelmod/arg_extractor.c
@@ -27,7 +27,7 @@ unsigned long get_arg(struct pt_regs* regs, int n)
 		case 5: return regs->r8;
 		case 6: return regs->r9;
 
-#elif defined(CONFIG_CPU_LOONGSON3)
+#elif defined(CONFIG_CPU_LOONGSON3) || defined(CONFIG_CPU_LOONGSON64)
 
 		case 1:  // a0
 		case 2:  // a1


### PR DESCRIPTION
If previous dkms deb package has install failed, it does not allow to install anymore, check its status and remove previous dkms dir if failed( status is added).

Log: fix dkms install issue.