### PR TITLE
fix: Fix cannot search issue by long time after startup.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-anything (6.1.1) unstable; urgency=medium
+
+  * fix can search issue for first start.
+  * fix dgb install issue.
+  * cmake build support.
+
+ -- Deepin Package Builder <packages@deepin.com>  Tue, 20 Jun 2023 16:32:58 +0800
+
 deepin-anything (6.1.0) unstable; urgency=medium
 
   * fix dkms install issue.

--- a/src/server/backend/anythingbackend.h
+++ b/src/server/backend/anythingbackend.h
@@ -23,8 +23,6 @@ public:
 
     int init_connection()noexcept;
 
-protected:
-
 private:
     int monitorStart();
     int backendRun();

--- a/src/server/backend/lib/lftmanager.h
+++ b/src/server/backend/lib/lftmanager.h
@@ -69,6 +69,9 @@ Q_SIGNALS:
     void autoIndexExternalChanged(bool autoIndexExternal);
     void autoIndexInternalChanged(bool autoIndexInternal);
 
+    // 创建索引完成
+    void buildFinished();
+
 protected:
     explicit LFTManager(QObject *parent = nullptr);
 
@@ -78,12 +81,13 @@ private:
     QTimer refresh_timer;
     uint cpu_row_count;
     bool cpu_limited;
+    QStringList building_paths;
     bool _isAutoIndexPartition() const;
 
     void _cpuLimitCheck();
     void _syncAll();
     void _indexAll();
-    void _indexAllDelay(int time = 10 * 60 * 1000);
+    void _indexAllDelay(int time = 30 * 1000);
     void _cleanAllIndex();
     void _addPathByPartition(const DBlockDevice *block);
     void onMountAdded(const QString &blockDevicePath, const QByteArray &mountPoint);


### PR DESCRIPTION
First, change the 10mins to 30s to build index and limit cpu usage when building. Second, create new task thread and add mutex for index update. Finally, change cpu checking interval to 10s in order to quick response.

Log: Fix cannot search issue after startup.