### PR TITLE
fix: Fix server core dump on restart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (6.1.8) unstable; urgency=medium
+
+  * fix server core dump on restart.
+
+ -- Deepin Package Builder <packages@deepin.com>  Thu, 07 Mar 2024 13:27:30 +0800
+
 deepin-anything (6.1.7) unstable; urgency=medium
 
   * update version.

--- a/src/server/backend/anythingbackend.cpp
+++ b/src/server/backend/anythingbackend.cpp
@@ -34,17 +34,19 @@ extern "C" ANYTHINGBACKEND_SHARED_EXPORT int fireAnything()
 
 extern "C" ANYTHINGBACKEND_SHARED_EXPORT void downAnything()
 {
-    delete AnythingBackend::instance();
+    // delete cause SIGSEGV
+    // delete AnythingBackend::instance();
 }
 
 AnythingBackend::~AnythingBackend()
 {
-    delete LFTManager::instance();
+    // delete LFTManager::instance();
 
     if (server && server->isRunning()) {
         server->terminate();
     }
-    LogSaver::instance()->uninstallMessageHandler();
+    // uninstall cause SIGSEGV
+    // LogSaver::instance()->uninstallMessageHandler();
 }
 
 AnythingBackend *AnythingBackend::instance()

--- a/src/server/backend/lib/lftmanager.cpp
+++ b/src/server/backend/lib/lftmanager.cpp
@@ -1094,9 +1094,9 @@ void LFTManager::_cpuLimitCheck()
             nWarning() << "Limited, long time high CPU usage: " << current_cpu;
 
             struct stat statbuf;
-            if (stat("/tmp/anything_disable_abort", &statbuf)) {
-                nWarning() << "Abort for high CPU usage.";
-                abort();
+            if (stat("/tmp/anything_disable_exit", &statbuf)) {
+                nWarning() << "Exit for high CPU usage.";
+                _exit(1);
             }
         } else if (current_cpu < low_use) {
             QProcess::startDetached(cmd);


### PR DESCRIPTION
Use exit() instead of abort() when server restart.

Log: Fix server core dump on restart