### PR TITLE
fix: Fix CPU limit check not working

### DIFF
--- a/src/library/src/fs_buf.c
+++ b/src/library/src/fs_buf.c
@@ -1399,8 +1399,10 @@ __attribute__((visibility("default"))) void parallelsearch_files(fs_buf *fsbuf, 
 
 	// init the compare query struct, which includes keyword, icase and language support.
 	compare_query_t *comquery = calloc(1, sizeof(compare_query_t));
-	if (comquery == NULL)
+	if (comquery == NULL) {
+		pthread_rwlock_unlock(&fsbuf->lock);
 		return; // make sure the comparator related would be setted correctly.
+	}
 
 	comquery->icase = icase > 0;
 	if (pinyin_enable > 0) {

--- a/src/server/backend/lib/lftmanager.h
+++ b/src/server/backend/lib/lftmanager.h
@@ -9,6 +9,8 @@
 #include <QObject>
 #include <QDBusContext>
 #include <QTimer>
+#include <QMutex>
+#include <QThread>
 
 class DBlockDevice;
 class LFTManager : public QObject, protected QDBusContext
@@ -80,6 +82,8 @@ protected:
 private:
     uint cpu_row_count;
     bool cpu_limited;
+    QMutex cpu_monitor_quit;
+    QThread *cpu_monitor_thread;
     QStringList building_paths;
     bool _isAutoIndexPartition() const;
 


### PR DESCRIPTION
Before the fix, the CPU limit check was triggered by a timer, which is unreliable because the main thread could get stuck while executing dbus requests. The solution is to use a separate thread to perform the CPU limit check.

Log: Fix CPU limit check not working