### PR TITLE
fix: fix crash caused by too long mount path

### DIFF
--- a/src/library/inc/walkdir.h
+++ b/src/library/inc/walkdir.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#define PART_NAME_MAX	128
+#define PART_NAME_MAX	256
 #define FS_TYPE_MAX		32
 
 typedef struct __partition__ {

--- a/src/library/src/walkdir.c
+++ b/src/library/src/walkdir.c
@@ -105,8 +105,22 @@ __attribute__((visibility("default"))) int get_partitions(int* part_count, parti
 	if (fp == 0)
 		return 1;
 
-	char dev[PART_NAME_MAX], mp[PART_NAME_MAX], fs_type[FS_TYPE_MAX];
-	while (fscanf(fp, "%s %s %s %*s %*d %*d\n", dev, mp, fs_type) == 3) {
+	char *dev = NULL, *mp = NULL, *fs_type = NULL;
+	while (1) {
+		free(dev); free(mp); free(fs_type);
+		dev = mp = fs_type = NULL;
+
+		if (fscanf(fp, "%ms %ms %ms %*s %*d %*d\n", &dev, &mp, &fs_type) != 3) {
+			free(dev); free(mp); free(fs_type);
+			break;
+		}
+
+		/* check dev/mp/fs_type is too long */
+		if (strlen(dev) >= PART_NAME_MAX ||
+			strlen(mp) >= PART_NAME_MAX ||
+			strlen(fs_type) >= FS_TYPE_MAX)
+			continue;
+
 		if (is_special_mount_point(mp, fs_type))
 			continue;
 		struct stat st = {0};


### PR DESCRIPTION
The anything server will get the partition list when creating the file index. If the mount path is too long, it will cause a buffer overflow. The solution is to use the dynamic allocation conversion specifier.

Log: fix crash caused by too long mount path
Bug: https://pms.uniontech.com/bug-view-262789.html