### PR TITLE
fix: fix crash caused by multi-threaded access

### DIFF
--- a/src/server/backend/lib/eventadaptor.h
+++ b/src/server/backend/lib/eventadaptor.h
@@ -10,9 +10,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QMutex>
-#include <QWaitCondition>
 #include <QQueue>
-#include <QThread>
 
 DAS_BEGIN_NAMESPACE
 
@@ -31,10 +29,6 @@ public:
     void pushEvent(QPair<QByteArray, QByteArray> &action);
     bool popEvent(QPair<QByteArray, QByteArray> *action);
 
-public slots:
-    void startWork();
-    void handleTaskFinish();
-
 public:
     OnHandleEvent onHandler;
 
@@ -46,45 +40,8 @@ private:
 
 private:
     QMutex mutex;
-    QWaitCondition waitCondition;
     QQueue<QPair<QByteArray, QByteArray>> action_buffers;
     QTimer handle_timer;
-    // 用于事件更新，串行进行
-    bool jobFinished = true;
-};
-
-class TaskThread : public QThread
-{
-    Q_OBJECT
-public:
-    explicit TaskThread(QObject *parent = nullptr) : QThread(parent) {}
-    ~TaskThread() override {
-        handleFunc = nullptr;
-        actionList.clear();
-        deleteLater();
-    }
-    void run() override
-    {
-        // 后台回调处理事件，更新索引
-        if (handleFunc)
-            handleFunc(actionList);
-
-        emit workFinished();
-    }
-
-public slots:
-    void setData(OnHandleEvent callbackFunc, QList<QPair<QByteArray, QByteArray>> &actions)
-    {
-        handleFunc = callbackFunc;
-        actionList = actions;
-    }
-
-signals:
-    void workFinished();
-
-private:
-    OnHandleEvent handleFunc = nullptr;
-    QList<QPair<QByteArray, QByteArray>> actionList;
 };
 
 DAS_END_NAMESPACE

--- a/src/server/backend/lib/lftdisktool.cpp
+++ b/src/server/backend/lib/lftdisktool.cpp
@@ -19,19 +19,17 @@ namespace LFTDiskTool {
 Q_GLOBAL_STATIC(DDiskManager, _global_diskManager)
 Q_LOGGING_CATEGORY(logN, "anything.normal.disktool", DEFAULT_MSG_TYPE)
 
-static deepin_anything_server::MountCacher *s_mountCacher = deepin_anything_server::MountCacher::instance();
-
 QByteArray pathToSerialUri(const QString &path)
 {
     // 避免使用QDir/QStorageInfo, 如果IO被阻塞（U盘正在被扫描或网络盘断网），则导致卡顿或假死
     // 向上找到路径的真实挂载点
-    const QString mountPoint = s_mountCacher->findMountPointByPath(path);
+    const QString mountPoint = deepin_anything_server::MountCacher::instance()->findMountPointByPath(path);
     if (mountPoint.isEmpty()) {
         nWarning() << "pathToSerialUri findMountPointByPath NULL for:" << path;
         return QByteArray();
     }
 
-    const QString device = s_mountCacher->getDeviceByPoint(mountPoint);
+    const QString device = deepin_anything_server::MountCacher::instance()->getDeviceByPoint(mountPoint);
     if (!device.startsWith("/dev/") || device.startsWith("/dev/loop") || device.compare("/dev/fuse") == 0) {
         nWarning() << "ingore device:" << device;
         return QByteArray();
@@ -51,7 +49,7 @@ QByteArray pathToSerialUri(const QString &path)
     if (block_id.isEmpty())
         return QByteArray();
 
-    const auto mount_info_map = s_mountCacher->getRootsByPoints({mountPoint.toLocal8Bit()});
+    const auto mount_info_map = deepin_anything_server::MountCacher::instance()->getRootsByPoints({mountPoint.toLocal8Bit()});
     QByteArray mount_root_path;
 
     // 只获取一个，返回就取第一个值
@@ -94,7 +92,7 @@ QByteArrayList fromSerialUri(const QByteArray &uri)
 
         if (_block_id == block_id) {
             const QByteArrayList &mount_points = block_obj->mountPoints();
-            const auto mount_point_infos = s_mountCacher->getRootsByPoints(mount_points);
+            const auto mount_point_infos = deepin_anything_server::MountCacher::instance()->getRootsByPoints(mount_points);
             QByteArrayList pathList;
 
             for (QByteArray mount_point : mount_points) {

--- a/src/server/backend/lib/mountcacher.cpp
+++ b/src/server/backend/lib/mountcacher.cpp
@@ -14,6 +14,9 @@ extern "C" {
 
 DAS_BEGIN_NAMESPACE
 
+class _MountCacher : public MountCacher {};
+Q_GLOBAL_STATIC(_MountCacher, mountCacherGlobal)
+
 /* error callback */
 static int parser_errcb(libmnt_table *tb, const char *filename, int line)
 {
@@ -34,14 +37,13 @@ struct SPMntTableDeleter
 
 MountCacher *MountCacher::instance()
 {
-    static MountCacher ins;
-    return &ins;
+    return mountCacherGlobal;
 }
 
 MountCacher::MountCacher(QObject *parent)
     : QObject(parent)
 {
-    mountPointList.clear();
+    updateMountPoints();
 }
 
 MountCacher::~MountCacher()
@@ -103,10 +105,6 @@ QString MountCacher::findMountPointByPath(const QString &path, bool hardreal)
 {
     QString result;
     QString result_path = path;
-    if (hardreal) {
-        // 如果跳过虚拟，查找真实设备的挂载点，须检查挂载信息是否已获取
-        checkCurrentMounts();
-    }
 
     Q_FOREVER {
         char *checkpath = QFile::encodeName(result_path).data();
@@ -158,7 +156,6 @@ bool MountCacher::pathMatchType(const QString &path, const QString &type)
 {
     bool result= false;
     QString point = findMountPointByPath(path);
-    checkCurrentMounts();
 
     for (MountPoint info: mountPointList) {
         if (point == info.mountTarget && type == info.mountType) {
@@ -173,7 +170,6 @@ bool MountCacher::pathMatchType(const QString &path, const QString &type)
 QMap<QByteArray, QString> MountCacher::getRootsByPoints(const QByteArrayList &pointList)
 {
     QMap<QByteArray, QString> map;
-    checkCurrentMounts();
 
     for (const QByteArray &point : pointList) {
         const QString target = QString(point);
@@ -191,7 +187,6 @@ QMap<QByteArray, QString> MountCacher::getRootsByPoints(const QByteArrayList &po
 QString MountCacher::getDeviceByPoint(const QString &point)
 {
     QString device;
-    checkCurrentMounts();
 
     for (MountPoint info: mountPointList) {
         if (point == info.mountTarget) {
@@ -205,7 +200,6 @@ QString MountCacher::getDeviceByPoint(const QString &point)
 // 获取所有根为指定的挂载点, 不指定则返回全部挂载点信息
 QList<MountPoint> MountCacher::getMountPointsByRoot(const QString &root)
 {
-    checkCurrentMounts();
     if (root == nullptr || !root.startsWith('/')) {
         return mountPointList;
     }
@@ -217,14 +211,6 @@ QList<MountPoint> MountCacher::getMountPointsByRoot(const QString &root)
         }
     }
     return list;
-}
-
-void MountCacher::checkCurrentMounts()
-{
-    if (mountPointList.isEmpty()) {
-        nWarning() << "mountPointList is empty, updat it first.";
-        updateMountPoints();
-    }
 }
 
 QDebug operator<<(QDebug debug, const MountPoint &mp)

--- a/src/server/backend/lib/mountcacher.h
+++ b/src/server/backend/lib/mountcacher.h
@@ -29,8 +29,8 @@ class MountCacher : public QObject
     Q_DISABLE_COPY(MountCacher)
 
 public:
+    ~MountCacher();
     static MountCacher *instance();
-    bool updateMountPoints();
     QString findMountPointByPath(const QString &path, bool hardreal = false);
     bool pathMatchType(const QString &path, const QString &type);
 
@@ -43,11 +43,12 @@ public:
     // 获取所有根为指定的挂载点, 不指定则返回全部挂载点信息
     QList<MountPoint> getMountPointsByRoot(const QString &root = nullptr);
 
-private:
-    explicit MountCacher(QObject *parent = nullptr);
-    ~MountCacher();
+public slots:
+    bool updateMountPoints();
 
-    void checkCurrentMounts();
+protected:
+    explicit MountCacher(QObject *parent = nullptr);
+
 private:
     QList<MountPoint> mountPointList;
 };


### PR DESCRIPTION
Remove the thread in `EventAdaptor` and use the main thread timer to dispatch events directly. `EventSource_GENL` asynchronously calls `MountCacher::updateMountPoints` to avoid multi-threaded access. Use `Q_GLOBAL_STATIC` to create a singleton, and do not allow static acquisition.

Log: fix deepin-anything-server crash
Bug: https://pms.uniontech.com/bug-view-264761.html