### PR TITLE
fix: fix findMountPointByPath crash

### DIFF
--- a/src/server/backend/lib/mountcacher.cpp
+++ b/src/server/backend/lib/mountcacher.cpp
@@ -107,8 +107,8 @@ QString MountCacher::findMountPointByPath(const QString &path, bool hardreal)
     QString result_path = path;
 
     Q_FOREVER {
-        char *checkpath = QFile::encodeName(result_path).data();
-        char *mount_point = mnt_get_mountpoint(checkpath);
+        QByteArray checkpath = QFile::encodeName(result_path);
+        char *mount_point = mnt_get_mountpoint(checkpath.data());
         if (nullptr != mount_point) {
             // nDebug() << path << " mountpoint: " << mount_point;
             result = QString(mount_point);


### PR DESCRIPTION
As title.

Log: fix deepin-anything-server crash.
Task: https://pms.uniontech.com/task-view-358761.html