### PR TITLE
feat: support start anything server by systemd service

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -33,8 +33,8 @@ Files: .gitignore
 Copyright: None
 License: CC0-1.0
 
-# xml toml json conf yaml policy
-Files: *.xml *.toml *.json *conf *.yaml *.policy
+# xml toml json conf yaml policy service
+Files: *.xml *.toml *.json *conf *.yaml *.policy *.service
 Copyright: None
 License: CC0-1.0
 

--- a/debian/deepin-anything-server.postinst
+++ b/debian/deepin-anything-server.postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+os_maj_ver=`cat /etc/os-version | grep MajorVersion | cut -d '=' -f2`
+if [ $os_maj_ver -gt 20 ]; then
+#DEBHELPER#
+fi
+
+exit 0

--- a/debian/deepin-anything-server.service
+++ b/debian/deepin-anything-server.service
@@ -1,0 +1,1 @@
+../src/server/app/deepin-anything-server.service

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ export QT_SELECT=5
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 
 %:
-	dh $@ --parallel --with dkms
+	dh $@ --parallel --with dkms,systemd
 
 override_dh_auto_configure:
 	dh_auto_configure -Scmake -- \

--- a/src/server/app/CMakeLists.txt
+++ b/src/server/app/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
 # binary
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+
+install (FILES deepin-anything-server.service DESTINATION lib/systemd/system)

--- a/src/server/app/deepin-anything-server.service
+++ b/src/server/app/deepin-anything-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Deepin anything server service
+After=dbus.service udisks2.service
+
+[Service]
+User=root
+Group=root
+ExecStart=/usr/bin/deepin-anything-server
+ExecStartPre=modprobe vfs_monitor
+ExecStopPost=rmmod vfs_monitor
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/src/server/app/main.cpp
+++ b/src/server/app/main.cpp
@@ -23,8 +23,8 @@ int main(int argc, char *argv[])
     app.setOrganizationName("deepin");
 
     if (fireAnything()) {
-        qCritical() << "fireAnything failed!";
-        abort();
+        qWarning() << "fireAnything failed!";
+        return -1;
     }
     signal(SIGTERM, handleSIGTERM);
 


### PR DESCRIPTION
On V20 system, the service will keep disable status, and the anything server will be started by dde-file-manager-daemon. On V25 system, the service will keep enable status.

Log: support start anything server by systemd service
Bug: https://pms.uniontech.com/bug-view-281871.html