### PR TITLE
Add support for s360x, ppc64le and riscv

### DIFF
--- a/src/kernelmod/arg_extractor.c
+++ b/src/kernelmod/arg_extractor.c
@@ -42,7 +42,7 @@ unsigned long get_arg(struct pt_regs* regs, int n)
 		case 3: return regs->r18;
 		case 4: return regs->r19;
 
-#elif defined(CONFIG_ARM64)
+#elif defined(CONFIG_ARM64) || defined (CONFIG_AARCH64)
 
 		/*修改ARM上anything不能使用的问题,寄存器地址不正确*/
 		case 1: return regs->regs[0];

--- a/src/kernelmod/arg_extractor.c
+++ b/src/kernelmod/arg_extractor.c
@@ -10,6 +10,18 @@
 #include <uapi/linux/ptrace.h>
 #endif
 
+#if defined(__powerpc64__)
+#ifndef CONFIG_PPC64LE
+#define CONFIG_PPC64LE 1
+#endif
+#endif
+
+#if defined(__s390x__)
+#ifndef CONFIG_S390X
+#define CONFIG_S390X 1
+#endif
+#endif
+
 unsigned long get_arg(struct pt_regs* regs, int n)
 {
 /*
@@ -49,6 +61,34 @@ unsigned long get_arg(struct pt_regs* regs, int n)
 		case 2: return regs->regs[1];
 		case 3: return regs->regs[2];
 		case 4: return regs->regs[3];
+
+#elif defined(CONFIG_S390X)
+
+		/* s390x argument registers: r2, r3, r4, r5 */
+		case 1: return regs->gprs[2];
+		case 2: return regs->gprs[3];
+		case 3: return regs->gprs[4];
+		case 4: return regs->gprs[5];
+
+#elif defined(CONFIG_PPC64LE)
+
+		/* PPC64LE argument registers: r3, r4, r5, r6, r7, r8, r9, r10 */
+		case 1: return regs->gpr[3];
+		case 2: return regs->gpr[4];
+		case 3: return regs->gpr[5];
+		case 4: return regs->gpr[6];
+		
+#elif defined(CONFIG_RISCV)
+
+		/* RISC-V argument registers: a0, a1, a2, a3, a4, a5, a6, a7 */
+		case 1: return regs->a0;
+		case 2: return regs->a1;
+		case 3: return regs->a2;
+		case 4: return regs->a3;
+		case 5: return regs->a4;
+		case 6: return regs->a5;
+		case 7: return regs->a6;
+		case 8: return regs->a7;
 
 #else
 		#error "The current architecture is not supported."


### PR DESCRIPTION
- Optimize recoginizing ARM
  * In some distributions, the ARM macro is CONFIG_AARCH64
- Add support for s360x, ppc64le and riscv