### PR TITLE
fix: Fix log files take up a lot of space

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-anything (6.2.2) unstable; urgency=medium
+
+  * New version 6.2.2.
+  * Fix log files take up a lot of space.
+  * Add support for s360x, ppc64le and riscv.
+  * Optimize recoginizing ARM.
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 07 Jan 2025 20:41:36 +0800
+
 deepin-anything (6.2.1) unstable; urgency=medium
 
   * adapt kernel module for LOONGARCH architecture.

--- a/src/server/backend/lib/lftmanager.cpp
+++ b/src/server/backend/lib/lftmanager.cpp
@@ -777,7 +777,7 @@ QStringList LFTManager::insertFileToLFTBuf(const QByteArray &file)
             /* 由于事件合并的原因, 会经常导致报告此类错误. 由于它不属于程序问题, 特此降低日志等级 */
             cDebug() << "Failed(Path Exists):" << mount_path;
         } else {
-            cWarning() << "Failed:" << mount_path << ", result:" << r;
+            cDebug() << "Failed:" << mount_path << ", result:" << r;
         }
     }
 


### PR DESCRIPTION
Previously, the anything would keep log files generated in the last 30 days. If a large number of logs were generated in a short period of time, it would take up a lot of space. Let's modify it to only keep the 10 most recent log files.

Log: Fix log files take up a lot of space.