### PR TITLE
fix: Fix search fail in immutable system

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (6.2.4) unstable; urgency=medium
+
+  * Fix search fail in immutable system
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 20 Mar 2025 15:52:31 +0800
+
 deepin-anything (6.2.3) unstable; urgency=medium
 
   * Fix search fail for invalid path.

--- a/src/server/backend/lib/lftdisktool.cpp
+++ b/src/server/backend/lib/lftdisktool.cpp
@@ -112,7 +112,8 @@ QByteArrayList fromSerialUri(const QByteArray &uri)
                 if (new_path.isEmpty()) {
                     pathList << mount_point;
                 } else {
-                    mount_point.append("/");
+                    if (!mount_point.endsWith('/'))
+                        mount_point.append("/");
                     pathList << mount_point.append(new_path);
                 }
             }

--- a/src/server/backend/lib/mountcacher.cpp
+++ b/src/server/backend/lib/mountcacher.cpp
@@ -112,6 +112,7 @@ QString MountCacher::findMountPointByPath(const QString &path, bool hardreal)
         if (nullptr != mount_point) {
             // nDebug() << path << " mountpoint: " << mount_point;
             result = QString(mount_point);
+            free(mount_point);
             if (hardreal) {
                 bool find_virtual = false;
                 for (MountPoint info: mountPointList) {


### PR DESCRIPTION
On immutable system, the root partition is mounted at both "/" and "/sysroot", and subdirectories of the root partition are subsequently mounted at "/". When an application searches, `anything` uses the search path to determine the mount point of the root directory of the corresponding partition. If the search path is "/sysroot/dirname", the mount point returned in this case should be "/sysroot", not "/" as returned by `mnt_get_mountpoint()`.

Log: Fix search fail in immutable system
Bug: https://pms.uniontech.com/bug-view-308297.html