### PR TITLE
chore: [tag] New version 6.2.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-anything (6.2.5) unstable; urgency=medium
+
+  * New version 6.2.5
+  * Merge Qt5 and Qt6 build.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 27 Mar 2025 13:25:42 +0800
+
 deepin-anything (6.2.4) unstable; urgency=medium
 
   * Fix search fail in immutable system


### PR DESCRIPTION
New version 6.2.5

Log: New version 6.2.5.

## Summary by Sourcery

Chores:
- Update the debian/changelog file to reflect the new version 6.2.5.