### PR TITLE
fix: Fix search fail in immutable system

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (6.2.7) unstable; urgency=medium
+
+  * Fix search fail in immutable system
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 22 Apr 2025 18:59:55 +0800
+
 deepin-anything (6.2.6) unstable; urgency=medium
 
   * New version 6.2.6

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(LIBPCRE REQUIRED libpcre)
+pkg_check_modules(MOUNT REQUIRED mount IMPORTED_TARGET)
 
 set(3RD_DIR "../../3rdparty")
 
@@ -41,6 +42,7 @@ target_link_libraries(
     ${PROJECT_NAME}
     ${GLIB_LIBRARIES}
     ${LIBPCRE_LIBRARIES}
+    ${MOUNT_LIBRARIES}
 )
 
 target_include_directories(
@@ -48,6 +50,7 @@ target_include_directories(
 PUBLIC
     ${GLIB_INCLUDE_DIRS}
     ${LIBPCRE_INCLUDE_DIRS}
+    ${MOUNT_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/inc
     ${CMAKE_CURRENT_LIST_DIR}/inc/index
     ${3RD_DIR}/fsearch

--- a/src/library/src/utils.c
+++ b/src/library/src/utils.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <iconv.h>
 #include <wchar.h>
+#include <libmount.h>
 
 #include "utils.h"
 
@@ -77,7 +78,59 @@ int write_file(int fd, char* head, uint32_t size)
 
 // 将搜索路径转换为挂载路径
 
-char* bfs_search(const char *start_path, dev_t target_dev, ino_t target_ino)
+GList *get_bind_mountpoints(const dev_t target_dev)
+{
+    // 初始化 libmount 上下文
+    struct libmnt_table *tb = mnt_new_table();
+    if (!tb)
+        return NULL;
+
+    // 加载内核挂载信息
+    if (mnt_table_parse_mtab(tb, "/proc/self/mountinfo") != 0) {
+        mnt_free_table(tb);
+        return NULL;
+    }
+
+    GList *mount_list = NULL;
+    struct libmnt_iter *itr = mnt_new_iter(MNT_ITER_FORWARD);
+    struct libmnt_fs *fs;
+
+    // 遍历所有挂载项
+    while (mnt_table_next_fs(tb, itr, &fs) == 0) {
+        if (mnt_fs_get_devno(fs) != target_dev)
+            continue;
+        if (g_strcmp0(mnt_fs_get_root(fs), "/") == 0)
+            continue;
+
+        // 使用 GLib 内存分配并添加到链表
+        gchar *path = g_strdup(mnt_fs_get_target(fs));
+        if (path) {
+            mount_list = g_list_prepend(mount_list, path);
+        }
+    }
+
+    // 清理 libmount 资源
+    mnt_free_iter(itr);
+    mnt_free_table(tb);
+
+    // 反转链表恢复原始顺序
+    return g_list_reverse(mount_list);
+}
+
+gboolean is_mount_point(GList *mounts, const gchar *dir)
+{
+    GList *iter;
+
+    for (iter = mounts; iter != NULL; iter = iter->next) {
+        if (g_strcmp0(dir, (char*)iter->data) == 0) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+char* bfs_search(GList *mounts, const char *start_path, dev_t target_dev, ino_t target_ino)
 {
     char *ret = NULL;
     // 保存了同一挂载中的目录
@@ -94,10 +147,11 @@ char* bfs_search(const char *start_path, dev_t target_dev, ino_t target_ino)
             g_autofree char *full_path = g_build_filename(current_path, entry, NULL);
             struct stat entry_st;
 
-            // 队列仅保存同一挂载中的目录
+            // 队列仅保存同一挂载中的目录, 且忽略绑定挂载
             if (lstat(full_path, &entry_st) == 0 &&
                 S_ISDIR(entry_st.st_mode) &&
-                entry_st.st_dev == target_dev) {
+                entry_st.st_dev == target_dev &&
+                !is_mount_point(mounts, full_path)) {
                 // 找到匹配项立即返回
                 if (entry_st.st_ino == target_ino) {
                     ret = g_steal_pointer(&full_path);
@@ -123,6 +177,8 @@ char* bfs_search(const char *start_path, dev_t target_dev, ino_t target_ino)
 char* find_matching_dir(const char *mount_dir, const char *search_dir)
 {
     struct stat search_st, mount_st;
+    GList *mounts;
+    char *ret;
 
     // 获取目标目录的元数据
     if (lstat(search_dir, &search_st) != 0 ||
@@ -138,7 +194,11 @@ char* find_matching_dir(const char *mount_dir, const char *search_dir)
     if (search_st.st_ino == mount_st.st_ino)
         return g_strdup(mount_dir);
 
-    return bfs_search(mount_dir, search_st.st_dev, search_st.st_ino);
+    mounts = get_bind_mountpoints(mount_st.st_dev);
+    ret = bfs_search(mounts, mount_dir, search_st.st_dev, search_st.st_ino);
+    g_list_free_full(mounts, (GDestroyNotify)g_free);
+
+    return ret;
 }
 
 static GHashTable *find_matching_dir_cache = NULL;


### PR DESCRIPTION
On immutable system, a bind mount of "/persistent/home" to "/home" is created. If there are only three partitions, "/", "/boot" and "swap", then when an application searches under "/home", "/home" will be converted to "/home" instead of the expected "/persistent/home". This is caused by not filtering out bind mount directories during conversion, let's ignore bind mount directories when converting search directories.

Log: Adapting to immutable systems
Bug: https://pms.uniontech.com/bug-view-313941.html

## Summary by Sourcery

Fix search functionality on immutable systems by correctly handling bind mount directories

Bug Fixes:
- Resolve an issue where search paths were not correctly converted on systems with bind mounts, particularly in immutable system configurations

Enhancements:
- Improve directory search algorithm to ignore bind mount directories during path conversion
- Add support for detecting and filtering out bind mount points using libmount

Build:
- Add libmount as a required dependency in the build configuration
- Update CMake configuration to link against mount libraries