### PR TITLE
feat: Filter out blacklisted data when refreshing the index

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (7.0.10) unstable; urgency=medium
+
+  * feat: Filter out blacklisted data when refreshing the index
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 22 Apr 2025 19:53:58 +0800
+
 deepin-anything (7.0.9) unstable; urgency=medium
 
   * chore: Update license information

--- a/src/server/src/core/config.cpp
+++ b/src/server/src/core/config.cpp
@@ -18,9 +18,10 @@ Config::Config()
 {
     // init path_blacklist_
     path_blacklist_ = {
-        "$HOME/.git",
-        "$HOME/.svn",
+        "/.git",
+        "/.svn",
         "$HOME/.cache",
+        "$HOME/.config",
         "$HOME/.local/share/Trash",
     };
     // Replace $HOME with actual home directory path
@@ -34,7 +35,6 @@ Config::Config()
 
 }
 
-
 bool Config::isPathInBlacklist(const std::string& path) const
 {
     for (const auto& blacklisted_path : path_blacklist_) {
@@ -45,7 +45,4 @@ bool Config::isPathInBlacklist(const std::string& path) const
     return false;
 }
 
-
-
-
-ANYTHING_NAMESPACE_END 
+ANYTHING_NAMESPACE_END

--- a/src/server/src/core/file_index_manager.cpp
+++ b/src/server/src/core/file_index_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "core/file_index_manager.h"
 #include "analyzers/AnythingAnalyzer.h"
+#include "core/config.h"
 
 #include <chrono>
 #include <filesystem>
@@ -638,7 +639,8 @@ bool file_index_manager::refresh_indexes() {
         for (const auto& score_doc : search_results->scoreDocs) {
             DocumentPtr doc = searcher_->doc(score_doc->doc);
             std::filesystem::path full_path(doc->get(L"full_path"));
-            if (!std::filesystem::exists(full_path, ec)) {
+            if (!std::filesystem::exists(full_path, ec) ||
+                Config::instance().isPathInBlacklist(full_path.string())) {
                 remove_list.push_back(full_path.string());
             } /*else {
                 auto last_write_time = file_helper_.get_file_last_write_time(full_path);


### PR DESCRIPTION
Filter out blacklisted data when refreshing the index. Modified the path blacklist in the Config class.

Log: Maintaining index consistency

## Summary by Sourcery

Enhance index refresh mechanism to filter out blacklisted paths

New Features:
- Add blacklist filtering during index refresh to prevent indexing of unwanted directories

Bug Fixes:
- Prevent indexing of system-specific hidden directories and cache folders

Enhancements:
- Modify path blacklist configuration to use more generic path matching
- Update file index manager to skip blacklisted paths during refresh