### PR TITLE
Pr0428

### DIFF
--- a/src/server/include/core/base_event_handler.h
+++ b/src/server/include/core/base_event_handler.h
@@ -156,7 +156,7 @@ private:
     std::vector<std::string> pending_paths_;
     std::vector<anything::index_job> jobs_;
     std::function<bool(const std::string&)> index_change_filter_;
-    anything::thread_pool pool_;
+    std::shared_ptr<anything::thread_pool> pool_;
     std::atomic<bool> stop_timer_;
     std::mutex jobs_mtx_;
     std::mutex pending_mtx_;

--- a/src/server/include/utils/tools.h
+++ b/src/server/include/utils/tools.h
@@ -20,6 +20,8 @@ char *format_size(int64_t size);
 
 char *get_full_path(const char *path);
 
+unsigned int get_thread_pool_size_from_env(unsigned int default_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/src/core/base_event_handler.cpp
+++ b/src/server/src/core/base_event_handler.cpp
@@ -10,13 +10,15 @@
 #include "utils/log.h"
 #include "utils/string_helper.h"
 #include <anythingadaptor.h>
+#include "utils/tools.h"
 
 #define COMMIT_VOLATILE_INDEX_TIMEOUT 10
 #define COMMIT_PERSISTENT_INDEX_TIMEOUT 600
 
 base_event_handler::base_event_handler(std::string persistent_index_dir, std::string volatile_index_dir, QObject *parent)
     : QObject(parent), index_manager_(std::move(persistent_index_dir), std::move(volatile_index_dir)), batch_size_(200),
-      pool_((std::max)(std::thread::hardware_concurrency() - 3, 1U)),
+      // 4 threads: main thread, event thread, dbus thread, timer thread
+      pool_(get_thread_pool_size_from_env(std::max(std::thread::hardware_concurrency() - 4, 1U))),
       stop_timer_(false),
       timer_(std::thread(&base_event_handler::timer_worker, this, 1000)),
       delay_mode_(true/*index_manager_.indexed()*/),

--- a/src/server/src/utils/tools.c
+++ b/src/server/src/utils/tools.c
@@ -238,3 +238,19 @@ char *get_full_path(const char *path)
     char *full_path = find_dir_full_path(mountpoint, path);
     return full_path;
 }
+
+// return 1 if env is not set
+unsigned int get_thread_pool_size_from_env(unsigned int default_size)
+{
+    const char *env_thread_pool_size = getenv("ANYTHING_THREAD_POOL_SIZE");
+    if (!env_thread_pool_size)
+        return default_size;
+
+    unsigned int size = atoi(env_thread_pool_size);
+    if (size < 1)
+        size = 1;
+    if (size > 128)
+        size = 128;
+
+    return size;
+}

--- a/src/server/src/utils/tools.c
+++ b/src/server/src/utils/tools.c
@@ -246,7 +246,12 @@ unsigned int get_thread_pool_size_from_env(unsigned int default_size)
     if (!env_thread_pool_size)
         return default_size;
 
-    unsigned int size = atoi(env_thread_pool_size);
+    char *end;
+    errno = 0;
+    unsigned int size = g_ascii_strtoull(env_thread_pool_size, &end, 10);
+    if (errno != 0 || *end != '\0')
+        return default_size;
+
     if (size < 1)
         size = 1;
     if (size > 128)


### PR DESCRIPTION
## Summary by Sourcery

Make the main thread pool size configurable via an environment variable and refine its initialization.

New Features:
- Introduce the `ANYTHING_THREAD_POOL_SIZE` environment variable to allow overriding the default thread pool size.
- Add `get_thread_pool_size_from_env` utility function to read and validate the environment variable.

Enhancements:
- Calculate the default thread pool size based on hardware concurrency minus reserved threads (main, event, dbus, timer).
- Change thread pool member in `base_event_handler` to use `std::shared_ptr`.
- Optimize locking in the timer worker by checking `pending_paths_` emptiness only once under the lock.