### PR TITLE
feat: migrate to pcre2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
  libpolkit-qt6-1-dev | libpolkit-qt5-1-dev,
  libmount-dev,
  libglib2.0-dev,
- libpcre3-dev,
+ libpcre2-dev,
  libnl-genl-3-dev,
 Standards-Version: 3.9.8
 Homepage: http://github.com/linuxdeepin/deepin-anything

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Setup the environment
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-pkg_check_modules(LIBPCRE REQUIRED libpcre)
+pkg_check_modules(LIBPCRE REQUIRED libpcre2-8)
 pkg_check_modules(MOUNT REQUIRED mount IMPORTED_TARGET)
 
 set(3RD_DIR "../../3rdparty")

--- a/src/library/Makefile
+++ b/src/library/Makefile
@@ -27,10 +27,13 @@ REALNAME = $(TARGET).$(PROJECT_VERSION)
 GLIB_INCL := $(shell pkg-config --cflags glib-2.0)
 GLIB_LIB := $(shell pkg-config --libs glib-2.0)
 
-INCLUDE_DIR := -Iinc -Iinc/index -I$(EXTERNAL_DIR)/fsearch ${GLIB_INCL}
+PCRE_INCL := $(shell pkg-config --cflags libpcre2-8)
+PCRE_LIB := $(shell pkg-config --libs libpcre2-8)
+
+INCLUDE_DIR := -Iinc -Iinc/index -I$(EXTERNAL_DIR)/fsearch ${GLIB_INCL} ${PCRE_INCL}
 
 CFLAGS := -std=gnu99 -Wall -Wl,--no-undefined -D_GNU_SOURCE ${INCLUDE_DIR} -shared -fPIC -fvisibility=hidden
-LDFLAGS := -lpthread -lpcre ${GLIB_LIB} -shared -Wl,-soname,$(REALNAME)
+LDFLAGS := -lpthread ${GLIB_LIB} ${PCRE_LIB} -shared -Wl,-soname,$(REALNAME)
 
 all: release debug
 


### PR DESCRIPTION
Log:

## Summary by Sourcery

Migrate the project from PCRE (Perl Compatible Regular Expressions) version 1 to PCRE2, updating the library dependencies, source code, and build configuration accordingly.

New Features:
- Upgraded to PCRE2 library for regular expression handling

Enhancements:
- Updated regex handling to use PCRE2 API
- Modified source code to be compatible with PCRE2 function calls

Build:
- Updated build configurations to use libpcre2-dev instead of libpcre3-dev
- Modified CMake and Makefile to link against PCRE2 library

Documentation:
- Updated README files to reflect new PCRE2 dependency