### PR TITLE
Pr0516

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-anything (7.0.15) unstable; urgency=medium
+
+  * fix: Improve filesystem existence checks with error handling
+  * refactor: Improve event path conflict detection
+  * fix: Continue receiving events after fail
+
+ -- wangrong <wangrong@uniontech.com>  Fri, 16 May 2025 16:50:56 +0800
+
 deepin-anything (7.0.14) unstable; urgency=medium
 
   * feat: Clean up event handling and logging

--- a/src/server/src/core/default_event_handler.cpp
+++ b/src/server/src/core/default_event_handler.cpp
@@ -17,10 +17,12 @@
 
 ANYTHING_NAMESPACE_BEGIN
 
-// 检查 event_path 是否已经包含在 indexing_items_ 中
-bool is_event_path_in_indexing_items(const std::string& event_path, const std::vector<indexing_item>& indexing_items) {
+// 检查 event_path 与 indexing_items_ 中的 event_path 是否冲突
+bool is_event_path_conflict_with_indexing_items(const std::string& event_path,
+                                                const std::vector<indexing_item>& indexing_items) {
     for (auto& item : indexing_items) {
-        if (string_helper::starts_with(event_path, item.event_path)) {
+        if (string_helper::starts_with(event_path, item.event_path) ||
+            string_helper::starts_with(item.event_path, event_path)) {
             return true;
         }
     }
@@ -50,8 +52,8 @@ std::string get_event_path(const std::string& origin_path, const std::vector<ind
         event_path_with_slash += "/";
     }
 
-    if (is_event_path_in_indexing_items(event_path_with_slash, indexing_items)) {
-        spdlog::warn("Event path {} is already configured, skip", event_path_with_slash);
+    if (is_event_path_conflict_with_indexing_items(event_path_with_slash, indexing_items)) {
+        spdlog::warn("Event path {} conflicts with already configured event paths, skip", event_path_with_slash);
         return "";
     }
 

--- a/src/server/src/core/disk_scanner.cpp
+++ b/src/server/src/core/disk_scanner.cpp
@@ -17,6 +17,7 @@ ANYTHING_NAMESPACE_BEGIN
 std::vector<std::string> disk_scanner::scan(const fs::path& root, const std::vector<std::string>& blacklist_paths) {
     spdlog::info("Scanning {}...", root.string());
     std::vector<std::string> records;
+    // By default, symlinks are not followed
     fs::recursive_directory_iterator dirpos{ root, fs::directory_options::skip_permission_denied };
     std::error_code ec;
     for (auto it = begin(dirpos); it != end(dirpos); ++it) {

--- a/src/server/src/core/event_listenser.cpp
+++ b/src/server/src/core/event_listenser.cpp
@@ -119,7 +119,7 @@ void event_listenser::start_listening() {
                 int ret = nl_recvmsgs_default(mcsk_);
                 if (ret < 0) {
                     spdlog::error("Failed to receive netlink messages: {}", ret);
-                    qApp->quit();
+                    // not exit, continue listening
                 }
             } else if (ep_events[i].data.fd == stop_fd_) {
                 uint64_t u;


### PR DESCRIPTION
## Summary by Sourcery

Enhance event path conflict detection logic, make the netlink-based event listener resilient to receive errors, and document the default symlink behavior in the disk scanner.

Enhancements:
- Expand event path validation to detect conflicts in both prefix directions and update warning messages accordingly
- Prevent the event listener from quitting on netlink receive failures to ensure continuous operation
- Clarify in code comments that the disk scanner does not follow symlinks by default