### PR TITLE
fix: Remove unnecessary own permission from DBus policy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (6.2.9) unstable; urgency=medium
+
+  * fix: Remove unnecessary own permission from DBus policy
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 19 May 2025 15:30:38 +0800
+
 deepin-anything (6.2.8) unstable; urgency=medium
 
   * feat: Not compile kernel module when in-tree ones already exist

--- a/src/server/backend/dbusservice/com.deepin.anything.conf
+++ b/src/server/backend/dbusservice/com.deepin.anything.conf
@@ -12,7 +12,6 @@
 
   <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
-    <allow own="com.deepin.anything"/>
     <allow send_destination="com.deepin.anything"/>
 
     <allow send_destination="com.deepin.anything"


### PR DESCRIPTION
As title.

Log: Remove unnecessary own permission from DBus policy

## Summary by Sourcery

Bug Fixes:
- Remove redundant own="com.deepin.anything" rule from com.deepin.anything.conf