### PR TITLE
Pr0522

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (7.0.17) unstable; urgency=medium
+
+  * fix: Fix scan "/" crash
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 22 May 2025 16:24:31 +0800
+
 deepin-anything (7.0.16) unstable; urgency=medium
 
   * fix: Enhance error handling in file index management

--- a/src/server/src/core/config.cpp
+++ b/src/server/src/core/config.cpp
@@ -228,6 +228,7 @@ Config::Config()
         if (replace_home_dir(path)) {
             continue;
         }
+        // not allow relative path
         if (!anything::string_helper::starts_with(path, "/")) {
             path.insert(0, "/");
             continue;
@@ -258,8 +259,8 @@ std::shared_ptr<event_handler_config> Config::make_event_handler_config()
     auto config = std::make_shared<event_handler_config>();
     config->persistent_index_dir = std::string(g_get_user_cache_dir()) + "/deepin-anything-server";
     config->volatile_index_dir = std::string(g_get_user_runtime_dir()) + "/deepin-anything-server";
-    // 4 threads: main thread, event thread, dbus thread, timer thread
-    std::size_t free_threads = std::max(std::thread::hardware_concurrency() - 4, 1U);
+    // 3 primary threads: event receiving thread, event filter thread, timer thread
+    std::size_t free_threads = std::max(std::thread::hardware_concurrency() - 3, 1U);
     config->thread_pool_size = get_thread_pool_size_from_env(free_threads);
     config->blacklist_paths = blacklist_paths_;
     config->indexing_paths = indexing_paths_;

--- a/src/server/src/core/default_event_handler.cpp
+++ b/src/server/src/core/default_event_handler.cpp
@@ -112,7 +112,9 @@ default_event_handler::default_event_handler(std::shared_ptr<event_handler_confi
     for (auto& item : indexing_items_) {
         indexing_paths.emplace_back(item.origin_path);
         // remove the last "/"
-        indexing_paths.back().pop_back();
+        if (indexing_paths.back() != "/") {
+            indexing_paths.back().pop_back();
+        }
     }
     set_index_dirs(indexing_paths);
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce absolute indexing paths, adjust thread pooling logic, and prevent improper root path modification

Bug Fixes:
- Avoid stripping the root '/' when trimming trailing slashes in event handler

Enhancements:
- Normalize indexing paths to always start with '/'
- Recalculate available thread pool size by reserving 3 primary threads instead of 4

Chores:
- Update Debian changelog