### PR TITLE
feat: Fix compile error and add support to kernel 6.15

### DIFF
--- a/src/kernelmod/event_merge.c
+++ b/src/kernelmod/event_merge.c
@@ -291,8 +291,13 @@ struct timer_list *t
 static inline void check_events(struct vfs_event **events_tosend)
 {
     if (!events_number) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+        timer_delete(&event_timeout_notify);
+        mpr_log("check_events, timer_delete\n");
+#else
         del_timer(&event_timeout_notify);
         mpr_log("check_events, del_timer\n");
+#endif
     } else if (1 == events_number) {
         mod_timer(&event_timeout_notify, jiffies + MERGE_TIMEOUT);
         mpr_log("check_events, mod_timer\n");


### PR DESCRIPTION
因为Linux 6.15 移除了函数 `del_timer` 导致 dkms 无法正常编译，所以将 `del_timer` 替换为了 `timer_delete`
附：以下是 6.12.17 的 `del_timer` 实现代码（`include/linux/timer.h`）
```cpp
/**
 * del_timer - Delete a pending timer
 * @timer:	The timer to be deleted
 *
 * See timer_delete() for detailed explanation.
 *
 * Do not use in new code. Use timer_delete() instead.
 *
 * Returns:
 * * %0	- The timer was not pending
 * * %1	- The timer was pending and deactivated
 */
static inline int del_timer(struct timer_list *timer)
{
	return timer_delete(timer);
}
```

## Summary by Sourcery

Enhancements:
- Use `timer_delete` instead of deprecated `del_timer` for Linux kernel ≥ 6.15