### PR TITLE
Pr0619

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-anything (6.2.10) unstable; urgency=medium
+
+  * fix: Fix fail to register dbus service
+  * fix: Fix fail to update index for symbolic links
+
+ -- wangrong <wangr@wangrong>  Thu, 19 Jun 2025 20:29:48 +0800
+
 deepin-anything (6.2.9) unstable; urgency=medium
 
   * fix: Remove unnecessary own permission from DBus policy

--- a/src/server/backend/dbusservice/com.deepin.anything.conf
+++ b/src/server/backend/dbusservice/com.deepin.anything.conf
@@ -5,8 +5,8 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
 
-  <!-- everybody is allowed to own the service on the D-Bus system bus -->
-  <policy user="deepin-anything">
+  <!-- Allow root user to own the service -->
+  <policy user="root">
     <allow own="com.deepin.anything"/>
   </policy>
 


### PR DESCRIPTION
## Summary by Sourcery

Improve mount point detection to correctly resolve symlinks on the same device and update the D-Bus service policy to allow root ownership

Enhancements:
- Detect symbolic links in findMountPointByPath and use the parent directory for mountpoint resolution when on the same device

Deployment:
- Change D-Bus policy to allow the root user to own com.deepin.anything service

Chores:
- Update Debian changelog version