### PR TITLE
feat: Add pinyin acronym to file index

### DIFF
--- a/src/daemon/include/core/pinyin_processor.h
+++ b/src/daemon/include/core/pinyin_processor.h
@@ -22,7 +22,7 @@ public:
 
     void load_pinyin_dict(const std::string& filename);
 
-    std::string convert_to_pinyin(const std::string& sentence);
+    void convert_to_pinyin(const std::string& sentence, std::string& pinyin_full, std::string& pinyin_acronym);
 
 private:
     unsigned int hex_to_dec(const std::string& hex_str);

--- a/src/daemon/src/core/file_index_manager.cpp
+++ b/src/daemon/src/core/file_index_manager.cpp
@@ -37,6 +37,7 @@ using namespace Lucene;
 struct file_record {
     std::string file_name;
     std::string file_name_pinyin;
+    std::string file_name_pinyin_acronym;
     std::string full_path;
     std::string file_type;
     std::string file_ext;
@@ -55,7 +56,8 @@ file_record make_file_record(const std::filesystem::path& p,
                              const std::map<std::string, std::string> &file_type_mapping) {
     file_record ret = {
         .file_name       = p.filename().string(),
-        .file_name_pinyin = pinyin_processor.convert_to_pinyin(p.filename().string()),
+        .file_name_pinyin = "",
+        .file_name_pinyin_acronym = "",
         .full_path       = p.string(),
         .file_type       = "other",
         .file_ext        = p.extension().string(),
@@ -63,6 +65,7 @@ file_record make_file_record(const std::filesystem::path& p,
         .file_size       = 0,
         .is_hidden       = false,
     };
+    pinyin_processor.convert_to_pinyin(ret.file_name, ret.file_name_pinyin, ret.file_name_pinyin_acronym);
 
     if (ret.file_ext.size() > 1) {
         ret.file_ext = ret.file_ext.substr(1);
@@ -73,7 +76,8 @@ file_record make_file_record(const std::filesystem::path& p,
     struct stat statbuf;
     if (lstat(ret.full_path.c_str(), &statbuf) != 0) {
         auto err = errno;
-        spdlog::warn("stat fail: {} {}", ret.full_path, strerror(err));
+        // The error is usually that the file does not exist, mainly because the index is not updated in time.
+        spdlog::debug("stat fail: {} {}", ret.full_path, strerror(err));
         return ret;
     } else {
         ret.modify_time = statbuf.st_mtim.tv_sec;
@@ -102,6 +106,7 @@ file_record make_file_record(const std::filesystem::path& p,
 #define FILE_SIZE_FIELD L"file_size"
 #define FILE_SIZE_STR_FIELD L"file_size_str"
 #define PINYIN_FIELD L"pinyin"
+#define PINYIN_ACRONYM_FIELD L"pinyin_acronym"
 #define IS_HIDDEN_FIELD L"is_hidden"
 
 DocumentPtr create_document(const file_record& record) {
@@ -141,6 +146,9 @@ DocumentPtr create_document(const file_record& record) {
     doc->add(newLucene<Field>(PINYIN_FIELD,
         StringUtils::toUnicode(record.file_name_pinyin),
         Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
+    doc->add(newLucene<Field>(PINYIN_ACRONYM_FIELD,
+        StringUtils::toUnicode(record.file_name_pinyin_acronym),
+        Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
 
     doc->add(newLucene<Field>(IS_HIDDEN_FIELD,
         (record.is_hidden ? L"Y" : L"N"),
@@ -150,7 +158,7 @@ DocumentPtr create_document(const file_record& record) {
 }
 
 
-#define INDEX_VERSION L"2"
+#define INDEX_VERSION L"3"
 #define INDEX_VERSION_FIELD L"index_version"
 
 file_index_manager::file_index_manager(const std::string& persistent_index_dir,

--- a/src/daemon/src/core/pinyin_processor.cpp
+++ b/src/daemon/src/core/pinyin_processor.cpp
@@ -46,7 +46,7 @@ void pinyin_processor::load_pinyin_dict(const std::string& filename) {
     }
 }
 
-std::string pinyin_processor::convert_to_pinyin(const std::string& sentence) {
+void pinyin_processor::convert_to_pinyin(const std::string& sentence, std::string& pinyin_full, std::string& pinyin_acronym) {
     auto results = split_utf8_characters(sentence);
     std::string new_sentence;
     std::string pinyin_temp;
@@ -108,9 +108,9 @@ std::string pinyin_processor::convert_to_pinyin(const std::string& sentence) {
 
     new_sentence += " " + pinyin_acronym_english;
     new_sentence += " " + pinyin_english;
-    // return new_sentence;
-    // 只返回全拼拼音，比如 “文件.txt” 只返回 “wenjian.txt”
-    return pinyin_english;
+
+    pinyin_full = std::move(pinyin_english);
+    pinyin_acronym = std::move(pinyin_acronym_english);
 }
 
 unsigned int pinyin_processor::hex_to_dec(const std::string& hex_str) {

--- a/src/searcher/searcher.cpp
+++ b/src/searcher/searcher.cpp
@@ -92,6 +92,7 @@ std::vector<std::string> Searcher::search(const std::string& path,
                     << "<\\>" << StringUtils::toUTF8(doc->get(L"modify_time_str"))
                     << "<\\>" << StringUtils::toUTF8(doc->get(L"file_size_str"))
                     << "<\\>" << StringUtils::toUTF8(doc->get(L"pinyin"))
+                    << "<\\>" << StringUtils::toUTF8(doc->get(L"pinyin_acronym"))
                     << "<\\>" << StringUtils::toUTF8(doc->get(L"is_hidden"));
                 std::string result = ss.str();
                 results.push_back(result);


### PR DESCRIPTION
- Updated the pinyin_processor to allow conversion of sentences into both full pinyin and pinyin acronyms.
- Modified the file_record structure to store the new pinyin acronym field.
- Adjusted document creation to include the pinyin acronym in the indexed documents.
- Updated index version to 3 to rebuild the index.
- Updated the searcher to retrieve and display the pinyin acronym alongside other file information.

Log: Add pinyin acronym to file index
Bug: https://pms.uniontech.com/bug-view-331655.html

## Summary by Sourcery

Add support for pinyin acronyms throughout the file indexing pipeline, including generation, storage, indexing, and search display

New Features:
- Generate pinyin acronyms alongside full pinyin in the pinyin_processor and attach them to file records
- Index the pinyin_acronym field in documents and include it in search result output

Enhancements:
- Bump index version to 3 to rebuild with the new field
- Change file stat failure logs from warn to debug level to reduce noise