### PR TITLE
Pr0904

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (7.0.27) unstable; urgency=medium
+
+  * fix: Fix deepin-anything-daemon core dump for uninitialized index_status_
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 04 Sep 2025 16:48:50 +0800
+
 deepin-anything (7.0.26) unstable; urgency=medium
 
   * feat: Add pinyin acronym to file index

--- a/src/daemon/src/core/base_event_handler.cpp
+++ b/src/daemon/src/core/base_event_handler.cpp
@@ -18,7 +18,6 @@ base_event_handler::base_event_handler(std::shared_ptr<event_handler_config> con
       batch_size_(200),
       pool_(1),
       stop_timer_(false),
-      timer_(std::thread(&base_event_handler::timer_worker, this, 1000)),
       delay_mode_(true/*index_manager_.indexed()*/),
       index_dirty_(false),
       volatile_index_dirty_(false),
@@ -27,6 +26,9 @@ base_event_handler::base_event_handler(std::shared_ptr<event_handler_config> con
       index_status_(anything::index_status::loading),
       event_process_thread_count_(0) {
     index_dirty_ = index_manager_.refresh_indexes(config_->blacklist_paths);
+
+    // The timer thread is started only after all initialization is completed
+    timer_ = std::thread(&base_event_handler::timer_worker, this, 1000);
 }
 
 base_event_handler::~base_event_handler() {


### PR DESCRIPTION
## Summary by Sourcery

Move timer thread initialization into the constructor body to ensure all members are fully initialized before starting the thread

Bug Fixes:
- Delay timer_worker thread start until after full initialization to prevent race conditions

Chores:
- Update Debian changelog