### PR TITLE
chore(CI): add debian check workflow

### DIFF
--- a/.github/workflows/call-api-check.yml
+++ b/.github/workflows/call-api-check.yml
@@ -1,0 +1,13 @@
+name: apiCheck
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api-check:
+    uses: linuxdeepin/.github/.github/workflows/api-check.yml@master
+    secrets: inherit

--- a/.github/workflows/call-debian-check.yml
+++ b/.github/workflows/call-debian-check.yml
@@ -1,0 +1,13 @@
+name: debianCheck
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  debian-check:
+    uses: linuxdeepin/.github/.github/workflows/debian-check.yml@master
+    secrets: inherit

--- a/.github/workflows/call-static-check.yml
+++ b/.github/workflows/call-static-check.yml
@@ -1,0 +1,13 @@
+name: staticCheck
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-check:
+    uses: linuxdeepin/.github/.github/workflows/static-check.yml@master
+    secrets: inherit


### PR DESCRIPTION
add debian check workflow

log: 增加debian检查工作流

## Summary by Sourcery

Add reusable GitHub Actions workflows to run API, Debian packaging, and static checks on pull requests.

CI:
- Introduce API check workflow triggered on pull_request_target events using shared organization workflow.
- Add Debian check workflow triggered on pull_request_target events using shared organization workflow.
- Add static analysis check workflow triggered on pull_request_target events using shared organization workflow.