### PR TITLE
feat: move index storage from XDG_CACHE_HOME to XDG_DATA_HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ debian/deepin-anything-server.debhelper.log
 .cursor/
 .specstory/
 .cursorindexingignore
+.claude/
 
 # kernelmod
 src/kernelmod/.Module.symvers.cmd

--- a/assets/org.deepin.anything.json
+++ b/assets/org.deepin.anything.json
@@ -69,7 +69,7 @@
             "visibility": "public"
         },
         "pic_file_suffix": {
-            "value": "ani;bmp;gif;ico;jpe;jpeg;jpg;pcx;png;psd;tga;tif;tiff;webp;wmf;svg",
+            "value": "ani;avif;avifs;bmp;bw;dci;eps;epsf;epsi;exr;gif;heic;heif;heis;heix;icns;ico;jpe;jpeg;jpg;kra;mng;ora;pcx;pic;png;psd;raf;ras;raw;rgb;rgba;sgi;svg;svgz;tga;tif;tiff;wbmp;webp;wmf;xcf;cr2;crw;nef;dng;arw;orf;rw2;pef;srw;mrw;x3f;dcr;kdc;3fr;nrw;mef;iiq;sr2;erf;mos;rwl",
             "serial": 0,
             "flags":[],
             "name": "Pic File Suffix",

--- a/src/daemon/src/core/config.cpp
+++ b/src/daemon/src/core/config.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <gio/gio.h>
 #include <unordered_set>
+#include <filesystem>
 
 #define COMMIT_VOLATILE_INDEX_TIMEOUT_DEFAULT 2
 #define COMMIT_VOLATILE_INDEX_TIMEOUT_MIN 1
@@ -252,10 +253,65 @@ Config::~Config() {
     g_object_unref(dbus_connection_);
 }
 
+static void migrate_index_dir(const std::string& old_dir, const std::string& new_dir) {
+    std::error_code ec;
+
+    // Skip if new directory already exists
+    if (std::filesystem::exists(new_dir, ec)) {
+        return;
+    }
+
+    // Skip if old directory doesn't exist
+    if (!std::filesystem::exists(old_dir, ec)) {
+        return;
+    }
+
+    spdlog::info("Migrating index from {} to {}", old_dir, new_dir);
+
+    // Create parent directory for new location
+    auto parent_path = std::filesystem::path(new_dir).parent_path();
+    if (!std::filesystem::exists(parent_path, ec)) {
+        std::filesystem::create_directories(parent_path, ec);
+        if (ec) {
+            spdlog::error("Failed to create parent directory {}: {}", parent_path.string(), ec.message());
+            return;
+        }
+    }
+
+    // Move the directory
+    std::filesystem::rename(old_dir, new_dir, ec);
+    if (ec) {
+        spdlog::error("Failed to migrate index directory: {}", ec.message());
+        // If rename fails (e.g., cross-device), try copy and remove
+        ec.clear();
+        std::filesystem::copy(old_dir, new_dir, std::filesystem::copy_options::recursive, ec);
+        if (ec) {
+            spdlog::error("Failed to copy index directory: {}", ec.message());
+            return;
+        }
+        ec.clear();
+        std::filesystem::remove_all(old_dir, ec);
+        if (ec) {
+            spdlog::warn("Failed to remove old index directory: {}", ec.message());
+        }
+    }
+
+    spdlog::info("Index migration completed successfully");
+}
+
 event_handler_config Config::make_event_handler_config()
 {
     event_handler_config config;
-    config.persistent_index_dir = std::string(g_get_user_cache_dir()) + "/deepin-anything-server";
+
+    // Use XDG_DATA_HOME for persistent index storage (instead of XDG_CACHE_HOME)
+    // This ensures the index survives cache cleaning operations
+    std::string old_index_dir = std::string(g_get_user_cache_dir()) + "/deepin-anything-server";
+    std::string new_index_dir = std::string(g_get_user_data_dir()) + "/deepin-anything-server";
+
+    // Migrate from old location to new location if needed
+    migrate_index_dir(old_index_dir, new_index_dir);
+
+    config.persistent_index_dir = new_index_dir;
     config.volatile_index_dir = config.persistent_index_dir;
     config.blacklist_paths = blacklist_paths_;
     config.indexing_paths = indexing_paths_;

--- a/src/daemon/src/main.cpp
+++ b/src/daemon/src/main.cpp
@@ -103,6 +103,8 @@ int main(int argc, char* argv[]) {
     event_listenser listenser;
     print_event_handler_config(event_handler_config);
     default_event_handler handler(event_handler_config);
+    // default_event_handler 实例化时, 可能会清空索引目录, 这里重新设置 running 标志
+    set_running_flag();
     listenser.set_handler([&handler](fs_event *event) {
         handler.handle(event);
     });

--- a/src/daemon/src/utils/running_flag.cpp
+++ b/src/daemon/src/utils/running_flag.cpp
@@ -96,6 +96,11 @@ void set_running_flag(void)
 
     std::string running_flag_path = get_running_flag_path();
 
+    if (g_file_test(running_flag_path.c_str(), G_FILE_TEST_EXISTS)) {
+        spdlog::debug("Running flag already exists at {}, skipping", running_flag_path);
+        return;
+    }
+
     if (!g_file_set_contents(running_flag_path.c_str(), "", -1, nullptr)) {
         spdlog::warn("Failed to set running flag at {}: {}", running_flag_path,
                      strerror(errno));


### PR DESCRIPTION
## Summary by Sourcery

Migrate persistent index storage to XDG data directory and improve process running-flag handling.

New Features:
- Store the persistent index in the XDG data directory instead of the cache directory and automatically migrate existing index data to the new location on startup.

Enhancements:
- Improve robustness of the running-flag mechanism by avoiding recreation when it already exists and resetting it after potential index directory removal.