### PR TITLE
chore: Bump version to 7.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-anything (7.0.41) unstable; urgency=medium
+
+  * Revert "fix: retry volatile index commit when thread pool is busy"
+  * refactor: unify index commit into job queue with load awareness
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 14 May 2026 15:48:33 +0800
+
 deepin-anything (7.0.40) unstable; urgency=medium
 
   * fix: retry volatile index commit when thread pool is busy


### PR DESCRIPTION
chore: Bump version to 7.0.41

As title.

Log: Bump version to 7.0.41

## Summary by Sourcery

Build:
- Update Debian packaging changelog to reflect version 7.0.41 release.