### PR TITLE
fix: support clang-built kernels in DKMS

### DIFF
--- a/src/kernelmod/CMakeLists.txt
+++ b/src/kernelmod/CMakeLists.txt
@@ -58,5 +58,8 @@ message("CMAKE_CURRENT_BINARY_DIR:" ${CMAKE_CURRENT_BINARY_DIR})
  # Install all source files
  install(FILES ${SRC_FILES} DESTINATION ${INSTALL_DIR})
 
+ # Install helper scripts with executable permission
+ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/dkms-make.sh DESTINATION ${INSTALL_DIR})
+
   # Install the module conf file
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/anything.conf DESTINATION /usr/lib/modules-load.d)

--- a/src/kernelmod/deepin-anything-dkms.dkms.in
+++ b/src/kernelmod/deepin-anything-dkms.dkms.in
@@ -1,8 +1,8 @@
 PACKAGE_VERSION="@PROJECT_VERSION@"
 
 PACKAGE_NAME="deepin-anything"
-MAKE[0]="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh build ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh clean ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 DEST_MODULE_LOCATION[0]="/updates/"
 BUILT_MODULE_NAME[0]="vfs_monitor"

--- a/src/kernelmod/dkms-make.sh
+++ b/src/kernelmod/dkms-make.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 guanzi008 <245205080@qq.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+action="${1:-modules}"
+kernel_source_dir="${2:-${kernel_source_dir:-/lib/modules/$(uname -r)/build}}"
+build_dir="${3:-$(pwd)}"
+
+case "$kernel_source_dir" in
+    /*) ;;
+    *) kernel_source_dir="$(pwd)/$kernel_source_dir" ;;
+esac
+
+case "$build_dir" in
+    /*) ;;
+    *) build_dir="$(pwd)/$build_dir" ;;
+esac
+
+kernel_source_dir="$(cd "$kernel_source_dir" && pwd -P)"
+build_dir="$(cd "$build_dir" && pwd -P)"
+
+case "$action" in
+    build|modules)
+        target="modules"
+        ;;
+    clean)
+        target="clean"
+        ;;
+    *)
+        echo "Usage: $0 {build|modules|clean} [kernel_source_dir] [build_dir]" >&2
+        exit 2
+        ;;
+esac
+
+compile_h="${kernel_source_dir}/include/generated/compile.h"
+
+if [ -r "$compile_h" ] && grep -qi 'LINUX_COMPILER.*clang' "$compile_h"; then
+    clang_major="$(sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' "$compile_h" | head -n 1)"
+
+    if [ -n "$clang_major" ] && command -v "clang-${clang_major}" >/dev/null 2>&1; then
+        cc="clang-${clang_major}"
+    elif command -v clang >/dev/null 2>&1; then
+        cc="clang"
+    else
+        echo "This kernel was built with clang, but clang${clang_major:+-${clang_major}} is not installed." >&2
+        exit 127
+    fi
+
+    if [ -n "$clang_major" ] && command -v "ld.lld-${clang_major}" >/dev/null 2>&1; then
+        ld="ld.lld-${clang_major}"
+    elif command -v ld.lld >/dev/null 2>&1; then
+        ld="ld.lld"
+    else
+        echo "This kernel was built with clang/LLD, but ld.lld${clang_major:+-${clang_major}} is not installed." >&2
+        exit 127
+    fi
+
+    clang_extra=""
+    if "$cc" -Wno-gcc-install-dir-libstdcxx -Werror -mfentry -c -x c /dev/null -o /tmp/deepin-anything-clang-test.o >/dev/null 2>&1; then
+        clang_extra="-Wno-gcc-install-dir-libstdcxx"
+        rm -f /tmp/deepin-anything-clang-test.o
+    fi
+
+    exec make -C "$kernel_source_dir" M="$build_dir" LLVM=1 CC="$cc $clang_extra" LD="$ld" "$target"
+fi
+
+exec make -C "$kernel_source_dir" M="$build_dir" "$target"

--- a/src/kernelmod/dkms.conf.in
+++ b/src/kernelmod/dkms.conf.in
@@ -1,8 +1,8 @@
 PACKAGE_VERSION="0.0"
 
 PACKAGE_NAME="deepin-anything"
-MAKE[0]="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh build ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh clean ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 DEST_MODULE_LOCATION[0]="/updates/"
 BUILT_MODULE_NAME[0]="vfs_monitor"

--- a/src/server/app/CMakeLists.txt
+++ b/src/server/app/CMakeLists.txt
@@ -32,4 +32,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 # binary
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
-install (FILES deepin-anything-server.service DESTINATION lib/systemd/system)
+install (FILES
+    deepin-anything-server.service
+    deepin-anything-server.timer
+    DESTINATION lib/systemd/system
+)

--- a/src/server/app/deepin-anything-server.service
+++ b/src/server/app/deepin-anything-server.service
@@ -10,6 +10,3 @@ ExecStartPre=modprobe vfs_monitor
 ExecStopPost=rmmod vfs_monitor
 Restart=always
 RestartSec=30
-
-[Install]
-WantedBy=multi-user.target

--- a/src/server/app/deepin-anything-server.timer
+++ b/src/server/app/deepin-anything-server.timer
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 guanzi008 <245205080@qq.com>
+# SPDX-License-Identifier: CC0-1.0
+
+[Unit]
+Description=Start Deepin anything server after graphical login settles
+
+[Timer]
+OnBootSec=90s
+Unit=deepin-anything-server.service
+Persistent=false
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

This change fixes two issues found when testing deepin-anything with a Linux 7.0.8 CachyOS kernel on deepin 25.

The DKMS build now uses a small wrapper script that detects clang-built kernels from `include/generated/compile.h` and builds the module with the matching clang/lld toolchain when available. GCC-built kernels keep the existing make path.

The server is also moved behind a systemd timer instead of being enabled directly from `multi-user.target`. On deepin 25 with the 7.0.8 kernel, loading `vfs_monitor` while the graphical login stack is still coming up can leave the machine stuck around LightDM. Delaying the service start lets LightDM finish first while still starting deepin-anything automatically after boot.

## Validation

Tested on deepin 25 with `7.0.8-cachyos-x64v3`:

- DKMS autoinstall completed for `vfs_monitor`
- system booted into the 7.0.8 kernel without hanging at LightDM
- `deepin-anything-server.timer` started the service after boot
- `deepin-anything-server.service` stayed active
- `vfs_monitor` was loaded
- `journalctl -b -p err..alert` reported no entries

Also ran local checks:

- `sh -n debian/deepin-anything-server.postinst src/kernelmod/dkms-make.sh`
- `systemd-analyze verify src/server/app/deepin-anything-server.timer`
- `git diff --cached --check`
