### PR TITLE
fix: support Linux 7 DKMS builds

### DIFF
--- a/src/kernelmod/CMakeLists.txt
+++ b/src/kernelmod/CMakeLists.txt
@@ -58,5 +58,8 @@ message("CMAKE_CURRENT_BINARY_DIR:" ${CMAKE_CURRENT_BINARY_DIR})
  # Install all source files
  install(FILES ${SRC_FILES} DESTINATION ${INSTALL_DIR})
 
+ # Install helper scripts with executable permission
+ install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/dkms-make.sh DESTINATION ${INSTALL_DIR})
+
   # Install the module conf file
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/anything.conf DESTINATION /usr/lib/modules-load.d)

--- a/src/kernelmod/deepin-anything-dkms.dkms.in
+++ b/src/kernelmod/deepin-anything-dkms.dkms.in
@@ -1,8 +1,8 @@
 PACKAGE_VERSION="@PROJECT_VERSION@"
 
 PACKAGE_NAME="deepin-anything"
-MAKE[0]="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh build ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh clean ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 DEST_MODULE_LOCATION[0]="/updates/"
 BUILT_MODULE_NAME[0]="vfs_monitor"

--- a/src/kernelmod/dkms-make.sh
+++ b/src/kernelmod/dkms-make.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 guanzi008 <245205080@qq.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+action="${1:-modules}"
+kernel_source_dir="${2:-${kernel_source_dir:-/lib/modules/$(uname -r)/build}}"
+build_dir="${3:-$(pwd)}"
+
+case "$kernel_source_dir" in
+    /*) ;;
+    *) kernel_source_dir="$(pwd)/$kernel_source_dir" ;;
+esac
+
+case "$build_dir" in
+    /*) ;;
+    *) build_dir="$(pwd)/$build_dir" ;;
+esac
+
+kernel_source_dir="$(cd "$kernel_source_dir" && pwd -P)"
+build_dir="$(cd "$build_dir" && pwd -P)"
+
+case "$action" in
+    build|modules)
+        target="modules"
+        ;;
+    clean)
+        target="clean"
+        ;;
+    *)
+        echo "Usage: $0 {build|modules|clean} [kernel_source_dir] [build_dir]" >&2
+        exit 2
+        ;;
+esac
+
+compile_h="${kernel_source_dir}/include/generated/compile.h"
+
+if [ "$target" = "clean" ]; then
+    exec make -C "$kernel_source_dir" M="$build_dir" "$target"
+fi
+
+if [ -r "$compile_h" ] && grep -qi 'LINUX_COMPILER.*clang' "$compile_h"; then
+    clang_major="$(sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' "$compile_h" | head -n 1)"
+
+    if [ -n "$clang_major" ] && command -v "clang-${clang_major}" >/dev/null 2>&1; then
+        cc="clang-${clang_major}"
+    elif command -v clang >/dev/null 2>&1; then
+        cc="clang"
+    else
+        echo "This kernel was built with clang, but clang${clang_major:+-${clang_major}} is not installed." >&2
+        exit 127
+    fi
+
+    if [ -n "$clang_major" ] && command -v "ld.lld-${clang_major}" >/dev/null 2>&1; then
+        ld="ld.lld-${clang_major}"
+    elif command -v ld.lld >/dev/null 2>&1; then
+        ld="ld.lld"
+    else
+        echo "This kernel was built with clang/LLD, but ld.lld${clang_major:+-${clang_major}} is not installed." >&2
+        exit 127
+    fi
+
+    clang_extra=""
+    tmp_obj="$(mktemp "${TMPDIR:-/tmp}/deepin-anything-clang-test.XXXXXX.o")"
+    trap 'rm -f "$tmp_obj"' EXIT HUP INT TERM
+    if "$cc" -Wno-gcc-install-dir-libstdcxx -Werror -mfentry -c -x c /dev/null -o "$tmp_obj" >/dev/null 2>&1; then
+        clang_extra="-Wno-gcc-install-dir-libstdcxx"
+    fi
+    rm -f "$tmp_obj" || true
+    trap - EXIT HUP INT TERM
+
+    exec make -C "$kernel_source_dir" M="$build_dir" LLVM=1 CC="$cc $clang_extra" LD="$ld" "$target"
+fi
+
+exec make -C "$kernel_source_dir" M="$build_dir" "$target"

--- a/src/kernelmod/dkms.conf.in
+++ b/src/kernelmod/dkms.conf.in
@@ -1,8 +1,8 @@
 PACKAGE_VERSION="0.0"
 
 PACKAGE_NAME="deepin-anything"
-MAKE[0]="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh build ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/dkms-make.sh clean ${kernel_source_dir} ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 DEST_MODULE_LOCATION[0]="/updates/"
 BUILT_MODULE_NAME[0]="vfs_monitor"

--- a/src/kernelmod/vfs_kretprobes.c
+++ b/src/kernelmod/vfs_kretprobes.c
@@ -15,6 +15,7 @@
 #include <linux/namei.h>
 #include <linux/version.h>
 #include <linux/atomic.h>
+#include <linux/err.h>
 
 #include "arg_extractor.h"
 #include "vfs_change_consts.h"
@@ -286,6 +287,24 @@ _DECL_CMN_KRP(sys_umount, path_umount);
         .kp.symbol_name = ""#fn"",\
     };
 
+#define DECL_VFS_INT_OR_PTR_RET_KRP(fn, act, de_i) static int on_##fn##_ent(struct kretprobe_instance *ri, struct pt_regs *regs)\
+    {\
+        return common_vfs_ent((struct vfs_event **)&(ri->data), (struct dentry *)get_arg(regs, de_i));\
+    }\
+    \
+    static int on_##fn##_ret(struct kretprobe_instance *ri, struct pt_regs *regs)\
+    {\
+        return common_vfs_ret_int_or_ptr((struct vfs_event **)&(ri->data), regs, act);\
+    }\
+    \
+    static struct kretprobe fn##_krp = {\
+        .entry_handler  = on_##fn##_ent,\
+        .handler        = on_##fn##_ret,\
+        .data_size      = sizeof(struct vfs_event *),\
+        .maxactive      = 64,\
+        .kp.symbol_name = ""#fn"",\
+    };
+
 /*
  * if kretprobe entry-handler returns a non-zero error,
  * then the handler will not be called.
@@ -334,11 +353,42 @@ fail:
     return 0;
 }
 
+static int common_vfs_ret_int_or_ptr(struct vfs_event **event, struct pt_regs *regs, int action)
+{
+    if (IS_ERR_VALUE(regs_return_value(regs)))
+        goto fail;
+
+    (*event)->action = action;
+    vfs_changed_entry(*event);
+    return 0;
+
+fail:
+    if (*event)
+        vfs_event_free(*event);
+    return 0;
+}
+
 // select dentry from vfs api by different kernel
 // If the vfs api in the subsequent kernel changes, please define a new macro branch.
 // The main work of the definition is to specify the position number (starting from 1) of
 // the dentry parameter according to the definition of vfs api.
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+// int vfs_create(struct mnt_idmap *, struct dentry *, umode_t, struct delegated_inode *);
+// int vfs_unlink(struct mnt_idmap *, struct inode *, struct dentry *, struct delegated_inode *);
+// struct dentry *vfs_mkdir(struct mnt_idmap *, struct inode *, struct dentry *, umode_t, struct delegated_inode *);
+// int vfs_rmdir(struct mnt_idmap *, struct inode *, struct dentry *, struct delegated_inode *);
+// int vfs_symlink(struct mnt_idmap *, struct inode *, struct dentry *, const char *, struct delegated_inode *);
+// int security_inode_create(struct inode *dir, struct dentry *dentry, umode_t mode);
+// int vfs_link(struct dentry *, struct mnt_idmap *, struct inode *, struct dentry *, struct delegated_inode *);
+DECL_VFS_KRP(vfs_create, ACT_NEW_FILE, 2);
+DECL_VFS_KRP(vfs_unlink, ACT_DEL_FILE, 3);
+DECL_VFS_INT_OR_PTR_RET_KRP(vfs_mkdir, ACT_NEW_FOLDER, 3);
+DECL_VFS_KRP(vfs_rmdir, ACT_DEL_FOLDER, 3);
+DECL_VFS_KRP(vfs_symlink, ACT_NEW_SYMLINK, 3);
+DECL_VFS_KRP(security_inode_create, ACT_NEW_FILE, 2);
+// select dest(4) dentry, not src(1) dentry
+DECL_VFS_KRP(vfs_link, ACT_NEW_LINK, 4);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
 // vfs-create: struct inode*, struct dentry*, umode_t, bool
 // vfs-unlink: struct inode*, struct dentry*, struct inode**
 // vfs-mkdir: struct inode*, struct dentry*, umode_t
@@ -348,7 +398,7 @@ fail:
 // vfs-link: struct dentry*, struct inode*, struct dentry*, struct inode**
 DECL_VFS_KRP(vfs_create, ACT_NEW_FILE, 2);
 DECL_VFS_KRP(vfs_unlink, ACT_DEL_FILE, 2);
-DECL_VFS_KRP(vfs_mkdir, ACT_NEW_FOLDER, 2);
+DECL_VFS_INT_OR_PTR_RET_KRP(vfs_mkdir, ACT_NEW_FOLDER, 2);
 DECL_VFS_KRP(vfs_rmdir, ACT_DEL_FOLDER, 2);
 DECL_VFS_KRP(vfs_symlink, ACT_NEW_SYMLINK, 2);
 DECL_VFS_KRP(security_inode_create, ACT_NEW_FILE, 2);
@@ -364,7 +414,7 @@ DECL_VFS_KRP(vfs_link, ACT_NEW_LINK, 3);
 // int vfs_link(struct dentry *, struct user_namespace *, struct inode *, struct dentry *, struct inode **);
 DECL_VFS_KRP(vfs_create, ACT_NEW_FILE, 3);
 DECL_VFS_KRP(vfs_unlink, ACT_DEL_FILE, 3);
-DECL_VFS_KRP(vfs_mkdir, ACT_NEW_FOLDER, 3);
+DECL_VFS_INT_OR_PTR_RET_KRP(vfs_mkdir, ACT_NEW_FOLDER, 3);
 DECL_VFS_KRP(vfs_rmdir, ACT_DEL_FOLDER, 3);
 DECL_VFS_KRP(vfs_symlink, ACT_NEW_SYMLINK, 3);
 DECL_VFS_KRP(security_inode_create, ACT_NEW_FILE, 2);


### PR DESCRIPTION
## Summary

This is the develop/snipe-based replacement for #216.

The Linux 7.0 kernel changed the VFS helper prototypes used by `vfs_monitor`. In particular, `vfs_create()` now passes the target `struct dentry *` as the second argument. The old probe code still read the third argument, which is `umode_t` on 7.0, and then dereferenced it as a dentry. That causes `on_vfs_create_ent` to hit a kernel Oops shortly after the module is loaded.

This patch adds a Linux 7.0+ probe mapping for the changed VFS signatures and handles `vfs_mkdir()` returning either an int status or a dentry pointer, depending on the kernel version.

It also keeps the DKMS build compatible with clang-built kernels by selecting the matching clang/lld toolchain from `include/generated/compile.h`. The compiler feature probe now uses `mktemp` so parallel DKMS builds do not share a fixed temporary object file.

The timer-based startup delay from #216 is intentionally not included; the LightDM hang was a symptom of the kernel Oops, not a service ordering issue.

## Validation

Tested on deepin 25 with `7.0.8-cachyos-x64v3`:

- `vfs_monitor.ko` builds with clang/lld selected from the kernel headers
- manual `insmod` succeeds
- creating and removing a test directory/file does not trigger a new Oops
- `rmmod vfs_monitor` succeeds and logs `vfs_monitor: clearup ok`

Build checks on the same machine:

- `6.12.65-amd64-desktop-rolling: build ok`
- `6.18.19-amd64-desktop-rolling: build ok`
- `7.0.8-cachyos-x64v3: build ok`
- `sh -n src/kernelmod/dkms-make.sh`
- `git diff --check origin/develop/snipe..HEAD`

## Summary by Sourcery

Add support for Linux 7.x VFS API changes and DKMS builds on clang-built kernels.

New Features:
- Add kretprobe mappings for Linux 7.x VFS helper prototypes, including handling vfs_mkdir() returning either an int or a dentry pointer.
- Introduce a DKMS helper script to build the kernel module using the kernel's clang/LLD toolchain when applicable.

Enhancements:
- Install the DKMS helper script as an executable alongside the kernel module sources.
- Guard VFS kretprobe handling against error return values to avoid kernel oops on failed operations.

Build:
- Add a dkms-make.sh script that auto-detects clang/LLD from the kernel's compile.h and configures the module build accordingly.