### PR TITLE
fix: fix daemon fail to init

### DIFF
--- a/src/daemon/src/main.cpp
+++ b/src/daemon/src/main.cpp
@@ -100,11 +100,11 @@ int main(int argc, char* argv[]) {
     detect_last_time_quit_status();
     set_running_flag();
 
-    event_listenser listenser;
     print_event_handler_config(event_handler_config);
     default_event_handler handler(event_handler_config);
     // default_event_handler 实例化时, 可能会清空索引目录, 这里重新设置 running 标志
     set_running_flag();
+    event_listenser listenser;
     listenser.set_handler([&handler](fs_event *event) {
         handler.handle(event);
     });


### PR DESCRIPTION
In the current implementation, the index verification operation is located between the event listening operation and the event receiving operation. If the index verification operation takes too long, the buffer may overflow due to storing a large number of file events, causing errors in event receiving and ultimately leading to daemon initialization failure.
The current solution is to move the event listening operation after the index verification operation.

在当前的实现中, 索引校验操作位于事件监听操作和事件接收操作之间,
如果索引校验操作耗时过长, 就可能导致缓冲区因保存了大量的文件事件
而发生溢出, 这会导致事件接收时报错, 进而导致 daemon 初始化失败.
当前的修复方案是将事件监听操作放到索引校验操作之后.

Log: 修复性能差的系统上索引更新失败
PMS: BUG-367093