### PR TITLE
fix(kernelmod): restrict genl multicast group binding by kernel capability

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/kernelmod/vfs_genl.c
+++ b/src/kernelmod/vfs_genl.c
@@ -5,6 +5,7 @@
 
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/stddef.h>
 #include <net/netlink.h>
 #include <net/genetlink.h>
 #include <linux/skbuff.h>
@@ -14,12 +15,57 @@
 #include "vfs_kgenl.h"
 #include "event.h"
 
+/*
+ * Detect multicast group binding restriction capability without relying on
+ * LINUX_VERSION_CODE, because this security feature may be backported.
+ *
+ * struct genl_multicast_group layout across kernel versions:
+ *   Case 1: { char name[GENL_NAMSIZ]; }
+ *       No flags field — binding cannot be restricted.
+ *   Case 2: { char name[GENL_NAMSIZ]; u8 flags; }
+ *       2.1: GENL_MCAST_CAP_SYS_ADMIN defined — set .flags = GENL_MCAST_CAP_SYS_ADMIN.
+ *       2.2: GENL_MCAST_CAP_SYS_ADMIN undefined — binding cannot be restricted.
+ *   Case 3: { char name[GENL_NAMSIZ]; u8 flags; u8 cap_sys_admin:1; }
+ *       Set .cap_sys_admin = 1.
+ *
+ * GENL_ADMIN_PERM governs genl_ops (operation) permissions, not multicast
+ * group binding, and cannot restrict group joins — it is not used here.
+ *
+ * Detection strategy:
+ *   - #ifdef GENL_MCAST_CAP_SYS_ADMIN tells us the flags value is available
+ *     (Case 2.1). The macro is defined iff the kernel headers support it,
+ *     regardless of kernel version.
+ *   - sizeof(struct genl_multicast_group) distinguishes the three layouts:
+ *       == GENL_NAMSIZ       → Case 1 (name only)
+ *       >  GENL_NAMSIZ       → has flags field (Case 2 or 3)
+ *       >  GENL_NAMSIZ + 1   → has cap_sys_admin bitfield (Case 3)
+ *   - All checks are compile-time constants; the compiler folds and
+ *     dead-code-eliminates accordingly.
+ *   - The mcgs array is defined without .flags/.cap_sys_admin (always
+ *     compiles). init_vfs_genl() patches the fields via pointer offsets
+ *     before registration, avoiding member-name references that don't
+ *     exist on all kernel versions.
+ *   - Event functions check vfsmonitor_mcg_restricted (a static const bool
+ *     initialized from the sizeof and #ifdef checks) so the compiler
+ *     eliminates the unreachable branch at -O1+.
+ */
+
+#ifdef GENL_MCAST_CAP_SYS_ADMIN
+#define VFSMONITOR_MCG_HAS_SYS_ADMIN_MACRO  1
+#else
+#define VFSMONITOR_MCG_HAS_SYS_ADMIN_MACRO  0
+#endif
+
 /* multicast group */
 enum vfsmonitor_multicast_groups {
     VFSMONITOR_MCG_DENTRY,
     VFSMONITOR_MCG_PROCESS_INFO,
 };
-static const struct genl_multicast_group vfsmonitor_mcgs[] = {
+
+/* Defined without .flags/.cap_sys_admin — always compiles regardless of
+ * struct layout. init_vfs_genl() patches the fields in before registration
+ * if the struct supports them. */
+static struct genl_multicast_group vfsmonitor_mcgs[] = {
     [VFSMONITOR_MCG_DENTRY] = { .name = VFSMONITOR_MCG_DENTRY_NAME, },
     [VFSMONITOR_MCG_PROCESS_INFO] = { .name = VFSMONITOR_MCG_PROCESS_INFO_NAME, },
 };
@@ -34,6 +80,18 @@ static struct genl_family vfsmonitor_gnl_family = {
     .mcgrps = vfsmonitor_mcgs,
     .n_mcgrps = ARRAY_SIZE(vfsmonitor_mcgs),
 };
+
+/* Compile-time struct layout detection. */
+#define VFSMONITOR_MCG_HAS_FLAGS  (sizeof(struct genl_multicast_group) > GENL_NAMSIZ)
+#define VFSMONITOR_MCG_HAS_CAP    (sizeof(struct genl_multicast_group) > (GENL_NAMSIZ + 1))
+
+/* True iff binding can actually be enforced:
+ *   Case 2.1 (flags + GENL_MCAST_CAP_SYS_ADMIN) or Case 3 (cap_sys_admin).
+ * The compiler folds this into constant propagation, so the event functions'
+ * early-return branch is eliminated when false. */
+static const bool vfsmonitor_mcg_restricted =
+    VFSMONITOR_MCG_HAS_CAP ||
+    (VFSMONITOR_MCG_HAS_FLAGS && VFSMONITOR_MCG_HAS_SYS_ADMIN_MACRO);
 
 // static const char* action_names[] = {"file-created", "link-created", "symlink-created", "dir-created", "file-deleted", "dir-deleted",
 //     "file-renamed", "dir-renamed", "file-renamed-from", "file-renamed-to", "dir-renamed-from", "dir-renamed-to"};
@@ -131,6 +189,9 @@ int vfs_notify_vfs_event(struct vfs_event *event)
 {
     int rc;
 
+    if (!vfsmonitor_mcg_restricted)
+        return 0;
+
     rc = vfs_notify_dentry_event(event);
     if (rc)
         return rc;
@@ -143,7 +204,48 @@ int vfs_notify_vfs_event(struct vfs_event *event)
 
 int init_vfs_genl(void)
 {
-    int ret = genl_register_family(&vfsmonitor_gnl_family);
+    int ret;
+    unsigned int i;
+
+    /* Verify offset assumptions: when the flags field exists it must be
+     * at offset GENL_NAMSIZ (right after name[GENL_NAMSIZ], no padding
+     * because u8 has alignment 1). */
+#ifdef GENL_MCAST_CAP_SYS_ADMIN
+    BUILD_BUG_ON(offsetof(struct genl_multicast_group, flags) != GENL_NAMSIZ);
+#endif
+    BUILD_BUG_ON(sizeof(struct genl_multicast_group) < GENL_NAMSIZ);
+
+    /* Skip registration when binding cannot be restricted, so the family
+     * is never exposed to unprivileged listeners. vfsmonitor_mcg_restricted
+     * is a compile-time constant, so this branch is eliminated when false. */
+    if (!vfsmonitor_mcg_restricted) {
+        mpr_info("kernel lacks multicast group binding restriction support, skip genl registration\n");
+        return 0;
+    }
+
+    /* Patch the restriction fields via pointer offsets (avoiding member-name
+     * references that don't exist on all kernel versions) before registering
+     * the family. The BUILD_BUG_ON above validates the flags offset.
+     *
+     *   Case 3: cap_sys_admin bitfield at offset GENL_NAMSIZ + 1.
+     *   Case 2.1: flags field at offset GENL_NAMSIZ.
+     * Both offsets are safe from padding: name (char) and u8 fields all have
+     * alignment 1. */
+    for (i = 0; i < ARRAY_SIZE(vfsmonitor_mcgs); i++) {
+        if (VFSMONITOR_MCG_HAS_CAP) {
+            /* Case 3: set cap_sys_admin = 1 */
+            *((u8 *)((char *)&vfsmonitor_mcgs[i] + GENL_NAMSIZ + 1)) = 1;
+        }
+#ifdef GENL_MCAST_CAP_SYS_ADMIN
+        else {
+            /* Case 2.1: set flags = GENL_MCAST_CAP_SYS_ADMIN */
+            *((u8 *)((char *)&vfsmonitor_mcgs[i] + GENL_NAMSIZ)) =
+                GENL_MCAST_CAP_SYS_ADMIN;
+        }
+#endif
+    }
+
+    ret = genl_register_family(&vfsmonitor_gnl_family);
     if (ret)
         mpr_err("init_vfs_genl fail: %d\n", ret);
     return ret;
@@ -151,5 +253,8 @@ int init_vfs_genl(void)
 
 void cleanup_vfs_genl(void)
 {
+    if (!vfsmonitor_mcg_restricted)
+        return;
+
     genl_unregister_family(&vfsmonitor_gnl_family);
 }


### PR DESCRIPTION
Detect genl_multicast_group layout at compile time and only register the family when binding can actually be restricted, avoiding exposure to unprivileged listeners on kernels without the restriction feature.

编译期检测 genl_multicast_group 结构布局，仅在内核支持绑定限制时
注册 family，避免在缺少该特性的内核上暴露给非特权监听者。

Log: 修复 genl 多播组绑定限制的内核版本兼容问题
PMS: BUG-370779, BUG-370781
Influence: 在不具备多播组绑定限制能力的内核上跳过 family 注册，避免非特权进程接收 vfs 监控事件，提升安全性。