### PR TITLE
fix: Update cppcheck workflow to use checkout@v7

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As title.

Log: Update cppcheck workflow to use checkout@v7

## Summary by Sourcery

CI:
- Bump actions/checkout in the cppcheck workflow from v3 to v7 and enable unsafe PR checkout to support analysis of pull request heads.