### PR TITLE
chore: Bump version to 7.0.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+deepin-anything (7.0.45) unstable; urgency=medium
+
+  * fix(kernelmod): restrict genl multicast group binding by kernel
+    capability
+  * fix: Update cppcheck workflow to use checkout@v7
+  * feat(dispatcher): add event dispatcher module with Unix socket IPC
+  * feat(server): add VFS event listening and dispatching
+  * refactor(event-listener): replace netlink with dispatcher socket
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 23 Jul 2026 23:13:43 +0800
+
 deepin-anything (7.0.44) unstable; urgency=medium
 
   * fix: fix daemon fail to init


### PR DESCRIPTION
As title.

Log: Bump version to 7.0.45

## Summary by Sourcery

Chores:
- Update Debian packaging metadata to reflect release 7.0.45.