### PR TITLE
chore: Bump version to 7.0.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-anything (7.0.46) unstable; urgency=medium
+
+  * fix(event-listener): delay quit on disconnect to detect server
+    restart
+
+ -- wangrong <wangrong@uniontech.com>  Fri, 24 Jul 2026 21:12:44 +0800
+
 deepin-anything (7.0.45) unstable; urgency=medium
 
   * fix(kernelmod): restrict genl multicast group binding by kernel


### PR DESCRIPTION
As title.

Log: Bump version to 7.0.46

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 7.0.46 release.