### PR TITLE
feat(daemon): handle ACT_CLOSE_WRITE_FILE event for index update

### DIFF
--- a/src/daemon/include/core/base_event_handler.h
+++ b/src/daemon/include/core/base_event_handler.h
@@ -55,6 +55,7 @@ protected:
     void add_index_delay(std::string path);
     void remove_index_delay(std::string path);
     void update_index_delay(std::string src, std::string dst);
+    void update_index_delay(std::string path);
     void scan_index_delay(std::string path);
     void recursive_update_index_delay(std::string src, std::string dst);
     void init_scan_index_delay(std::string path);

--- a/src/daemon/include/core/file_index_manager.h
+++ b/src/daemon/include/core/file_index_manager.h
@@ -44,6 +44,11 @@ public:
     /// @param new_path The new path to be added to the index.
     bool update_index(const std::string& old_path, const std::string& new_path);
 
+    /// @brief Update the index for a file that has been written and closed.
+    ///        Skips the update if the target file does not exist.
+    /// @param path The full path of the modified file.
+    bool update_index(const std::string& path);
+
     /// Commit all changes to the index
     bool commit(index_status status);
 

--- a/src/daemon/src/core/base_event_handler.cpp
+++ b/src/daemon/src/core/base_event_handler.cpp
@@ -159,6 +159,10 @@ void base_event_handler::update_index_delay(std::string src, std::string dst) {
     jobs_push(std::move(src), anything::index_job_type::update, std::move(dst));
 }
 
+void base_event_handler::update_index_delay(std::string path) {
+    jobs_push(std::move(path), anything::index_job_type::update);
+}
+
 void base_event_handler::scan_index_delay(std::string path) {
     jobs_push(std::move(path), anything::index_job_type::scan);
 }
@@ -243,6 +247,8 @@ void base_event_handler::eat_job(const anything::index_job& job) {
         case anything::index_job_type::update:
             if (job.dst) {
                 ret = index_manager_.update_index(job.src, *job.dst);
+            } else {
+                ret = index_manager_.update_index(job.src);
             }
             break;
         case anything::index_job_type::scan:

--- a/src/daemon/src/core/default_event_handler.cpp
+++ b/src/daemon/src/core/default_event_handler.cpp
@@ -203,6 +203,7 @@ bool default_event_handler::prepare_event(fs_event *fs_evt,
     case ACT_NEW_FOLDER:
     case ACT_DEL_FILE:
     case ACT_DEL_FOLDER:
+    case ACT_CLOSE_WRITE_FILE:
         out->act = fs_evt->act;
         out->src = fs_evt->src;
         out->dst = "";
@@ -252,7 +253,12 @@ bool default_event_handler::prepare_event(fs_event *fs_evt,
 }
 
 void default_event_handler::filter_event(fs_event *fs_evt) {
-    [[maybe_unused]] const char* act_names[] = {"file_created", "link_created", "symlink_created", "dir_created", "file_deleted", "dir_deleted", "file_renamed", "dir_renamed"};
+    [[maybe_unused]] const char* act_names[] = {
+        "file_created", "link_created", "symlink_created", "dir_created",
+        "file_deleted", "dir_deleted",
+        "file_renamed", "dir_renamed", "file_renamed_from", "file_renamed_to", "dir_renamed_from", "dir_renamed_to",
+        "mount", "unmount",
+        "file_close_write" };
 
     fs_event_with_full_path event;
     if (!prepare_event(fs_evt, &event))
@@ -275,6 +281,9 @@ void default_event_handler::filter_event(fs_event *fs_evt) {
         // Do not check for the existence of files; we trust the kernel module.
         convert_event_path_to_origin_path(event.src, *src_indexing_item);
         add_index_delay(std::move(event.src));
+    } else if (event.act == ACT_CLOSE_WRITE_FILE) {
+        convert_event_path_to_origin_path(event.src, *src_indexing_item);
+        update_index_delay(std::move(event.src));
     } else if (event.act == ACT_DEL_FILE || event.act == ACT_DEL_FOLDER) {
         convert_event_path_to_origin_path(event.src, *src_indexing_item);
         remove_index_delay(std::move(event.src));

--- a/src/daemon/src/core/file_index_manager.cpp
+++ b/src/daemon/src/core/file_index_manager.cpp
@@ -311,6 +311,29 @@ bool file_index_manager::update_index(const std::string& old_path, const std::st
     return ret;
 }
 
+bool file_index_manager::update_index(const std::string& path) {
+    auto record = make_file_record(path, pinyin_processor_, file_type_mapping_);
+    if (record.modify_time == 0) {
+        spdlog::debug("Skip updating index for non-existent file: {}", path);
+        return true;
+    }
+
+    bool ret = false;
+
+    try {
+        auto doc = create_document(record);
+        writer_->updateDocument(newLucene<Term>(FULL_PATH_FIELD, StringUtils::toUnicode(path)), doc);
+        spdlog::debug("Updated index for {}", path);
+        ret = true;
+    } catch (const LuceneException& e) {
+        spdlog::error("Failed to update index for {}: {}", path, StringUtils::toUTF8(e.getError()));
+    } catch (const std::exception& e) {
+        spdlog::error("Failed to update index for {}: {}", path, e.what());
+    }
+
+    return ret;
+}
+
 bool check_index_corrupted(const std::string& index_directory) {
     try {
         FSDirectoryPtr dir = FSDirectory::open(StringUtils::toUnicode(index_directory));

--- a/src/server/event-dispatcher.c
+++ b/src/server/event-dispatcher.c
@@ -150,33 +150,6 @@ static gboolean convert_fs_event(ServerEventDispatcher *dispatcher,
 {
     dispatch_fs_event_init(out);
 
-    if (event->act == ACT_MOUNT || event->act == ACT_UNMOUNT) {
-        g_debug("%s: %s",
-                event->act == ACT_MOUNT ? "Mount a device" : "Unmount a device",
-                event->src);
-        mount_info_update(dispatcher->mount_info);
-        return TRUE;
-    }
-
-    gchar *root = NULL;
-    if (event->act < ACT_MOUNT) {
-        out->device_id = makedev(event->major, event->minor);
-
-        const gchar *mount_point = mount_info_get_device_mount_point(
-            dispatcher->mount_info, out->device_id);
-        if (!mount_point) {
-            g_debug("Unknown device: %u, dev: %u:%u, path: %s, cookie: %u",
-                    +event->act, event->major, +event->minor,
-                    event->src, event->cookie);
-            return TRUE;
-        }
-        root = g_strdup(mount_point);
-        if (g_strcmp0(root, "/") == 0) {
-            g_free(root);
-            root = NULL;
-        }
-    }
-
     switch (event->act) {
     case ACT_NEW_FILE:
     case ACT_NEW_SYMLINK:
@@ -184,62 +157,79 @@ static gboolean convert_fs_event(ServerEventDispatcher *dispatcher,
     case ACT_NEW_FOLDER:
     case ACT_DEL_FILE:
     case ACT_DEL_FOLDER:
+    case ACT_CLOSE_WRITE_FILE:
         out->act = event->act;
         out->src = g_strdup(event->src);
         out->dst = g_strdup("");
         break;
+
     case ACT_RENAME_FROM_FILE:
     case ACT_RENAME_FROM_FOLDER:
         g_hash_table_insert(dispatcher->rename_from,
                             GUINT_TO_POINTER(event->cookie),
                             g_strdup(event->src));
-        g_free(root);
         return TRUE;
+
     case ACT_RENAME_TO_FILE:
     case ACT_RENAME_TO_FOLDER: {
         gpointer from_src = g_hash_table_lookup(dispatcher->rename_from,
                                                 GUINT_TO_POINTER(event->cookie));
-        if (from_src) {
-            out->act = (event->act == ACT_RENAME_TO_FILE)
-                           ? ACT_RENAME_FILE : ACT_RENAME_FOLDER;
-            out->cookie = event->cookie;
-            out->dst = g_strdup(event->src);
-            out->src = g_strdup((const gchar *)from_src);
-            g_hash_table_remove(dispatcher->rename_from,
-                                GUINT_TO_POINTER(event->cookie));
-        } else {
+        if (!from_src) {
             g_debug("Rename-to without matching rename-from (cookie=%u)",
                     event->cookie);
-            g_free(root);
             return TRUE;
         }
+        out->act = (event->act == ACT_RENAME_TO_FILE)
+                       ? ACT_RENAME_FILE : ACT_RENAME_FOLDER;
+        out->cookie = event->cookie;
+        out->src = g_strdup((const gchar *)from_src);
+        out->dst = g_strdup(event->src);
+        g_hash_table_remove(dispatcher->rename_from,
+                            GUINT_TO_POINTER(event->cookie));
         break;
     }
+
     case ACT_RENAME_FILE:
     case ACT_RENAME_FOLDER:
-        g_warning("Unsupported file action: %u", +event->act);
-        g_free(root);
+        g_warning("Unsupported file action: %u", (guint)event->act);
         return TRUE;
+
+    case ACT_MOUNT:
+    case ACT_UNMOUNT:
+        g_debug("%s: %s",
+                event->act == ACT_MOUNT ? "Mount a device" : "Unmount a device",
+                event->src);
+        mount_info_update(dispatcher->mount_info);
+        return TRUE;
+
     default:
-        g_warning("Unknown file action: %u", +event->act);
-        g_free(root);
+        g_warning("Unknown file action: %u", (guint)event->act);
         return TRUE;
     }
 
-    if (root) {
+    out->device_id = makedev(event->major, event->minor);
+    const gchar *mount_point = mount_info_get_device_mount_point(
+        dispatcher->mount_info, out->device_id);
+    if (!mount_point) {
+        g_debug("Unknown device: %u, dev: %u:%u, path: %s, cookie: %u",
+                (guint)event->act, event->major, (guint)event->minor,
+                event->src, event->cookie);
+        return TRUE;
+    }
+
+    if (g_strcmp0(mount_point, "/") != 0) {
         if (out->src) {
-            gchar *new_src = g_strconcat(root, out->src, NULL);
+            gchar *prefixed = g_strconcat(mount_point, out->src, NULL);
             g_free(out->src);
-            out->src = new_src;
+            out->src = prefixed;
         }
         if (out->dst && out->dst[0] != '\0') {
-            gchar *new_dst = g_strconcat(root, out->dst, NULL);
+            gchar *prefixed = g_strconcat(mount_point, out->dst, NULL);
             g_free(out->dst);
-            out->dst = new_dst;
+            out->dst = prefixed;
         }
     }
 
-    g_free(root);
     return FALSE;
 }
 


### PR DESCRIPTION
Add ACT_CLOSE_WRITE_FILE event handling to update file index when a file is written and closed, skipping non-existent files.

添加 ACT_CLOSE_WRITE_FILE 事件处理，文件写入关闭后更新索引，
通过 make_file_record 判断文件是否存在，不存在则跳过。

Log: 添加文件写入关闭事件的索引更新处理
PMS: BUG-370789
Influence: 文件被写入并关闭后，索引将自动更新文件元数据，保证搜索结果时效性。