### PR TITLE
chore: Bump version to 7.0.47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,12 +98,6 @@ debian/deepin-anything-server.postrm.debhelper
 debian/deepin-anything-server.prerm.debhelper
 debian/deepin-anything-server.debhelper.log
 
-# AI
-.cursor/
-.specstory/
-.cursorindexingignore
-.claude/
-
 # kernelmod
 src/kernelmod/.Module.symvers.cmd
 src/kernelmod/.modules.order.cmd

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-anything (7.0.47) unstable; urgency=medium
+
+  * feat(kernelmod): track file close-write events
+  * feat(daemon): handle ACT_CLOSE_WRITE_FILE event for index update
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 27 Jul 2026 15:41:13 +0800
+
 deepin-anything (7.0.46) unstable; urgency=medium
 
   * fix(event-listener): delay quit on disconnect to detect server


### PR DESCRIPTION
As title.

Log: Bump version to 7.0.47

## Summary by Sourcery

Chores:
- Align .gitignore and Debian changelog with the 7.0.47 release version.