### PR TITLE
fix(kernelmod): add missing parentheses in cmp_event_path macro

### DIFF
--- a/src/kernelmod/event_merge.c
+++ b/src/kernelmod/event_merge.c
@@ -44,7 +44,7 @@ typedef int (*merge_action_fn_t)(struct list_head* entry, struct vfs_event *cur)
     --events_number;\
 }
 
-#define cmp_event_path(e1, e2) e1->dev != e2->dev ||  strcmp(e1->path, e2->path)
+#define cmp_event_path(e1, e2) ((e1)->dev != (e2)->dev || strcmp((e1)->path, (e2)->path))
 
 /*
  * merge rules


### PR DESCRIPTION
Wrap the cmp_event_path macro expression in parentheses to prevent operator precedence issues when used in larger expressions.

为 cmp_event_path 宏表达式添加括号，防止在复杂表达式中使用时出现运算符优先级问题。

Log: 修复 cmp_event_path 宏缺少括号的问题
PMS: BUG-370789
Influence: 修复后宏在复杂表达式中能正确求值，避免事件路径比较逻辑错误。

## Summary by Sourcery

Bug Fixes:
- Fix incorrect operator precedence in the cmp_event_path macro that could cause event path comparisons to be evaluated incorrectly in complex expressions.