### PR TITLE
chore: Bump version to 7.0.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (7.0.48) unstable; urgency=medium
+
+  * fix(kernelmod): add missing parentheses in cmp_event_path macro
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 28 Jul 2026 16:55:49 +0800
+
 deepin-anything (7.0.47) unstable; urgency=medium
 
   * feat(kernelmod): track file close-write events


### PR DESCRIPTION
As title.

Log: Bump version to 7.0.48

## Summary by Sourcery

Chores:
- Update Debian changelog entry for version 7.0.48.