### PR TITLE
fix: fix daemon fail to init

### DIFF
--- a/src/daemon/include/anything.hpp
+++ b/src/daemon/include/anything.hpp
@@ -6,7 +6,7 @@
 #define ANYTHING_ANYTHING_HPP_
 
 #include "core/default_event_handler.h"
-#include "core/event_listenser.h"
+#include "core/event_listener.h"
 #include "utils/log.h"
 
 #endif // ANYTHING_ANYTHING_HPP_

--- a/src/daemon/include/core/event_listener.h
+++ b/src/daemon/include/core/event_listener.h
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifndef ANYTHING_EVENT_LISTENSER_H_
-#define ANYTHING_EVENT_LISTENSER_H_
+#ifndef ANYTHING_EVENT_LISTENER_H_
+#define ANYTHING_EVENT_LISTENER_H_
 
 #include <atomic>
 #include <functional>
@@ -22,10 +22,10 @@ ANYTHING_NAMESPACE_BEGIN
 using nl_sock_ptr = nl_sock*;
 using nl_msg_ptr  = nl_msg*;
 
-class event_listenser {
+class event_listener {
 public:
-    event_listenser();
-    ~event_listenser();
+    event_listener();
+    ~event_listener();
 
     void start_listening();
 
@@ -56,4 +56,4 @@ private:
 
 ANYTHING_NAMESPACE_END
 
-#endif // ANYTHING_EVENT_LISTENSER_H_
+#endif // ANYTHING_EVENT_LISTENER_H_

--- a/src/daemon/src/core/event_listener.cpp
+++ b/src/daemon/src/core/event_listener.cpp
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "core/event_listenser.h"
+#include "core/event_listener.h"
 
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -56,7 +56,7 @@ bool set_max_socket_receive_buffer_size(nl_sock_ptr& sk) {
     return true;
 }
 
-event_listenser::event_listenser()
+event_listener::event_listener()
     : connected_{ connect(mcsk_) },
       timeout_{ -1 } {
     auto clean_and_exit = [this] {
@@ -89,7 +89,7 @@ event_listenser::event_listenser()
         clean_and_exit();
     }
 
-    if (!set_callback(mcsk_, event_listenser::event_handler)) {
+    if (!set_callback(mcsk_, event_listener::event_handler)) {
         spdlog::error("Error: failed to set callback");
         clean_and_exit();
     }
@@ -109,12 +109,12 @@ event_listenser::event_listenser()
     vfs_policy[VFSMONITOR_A_PATH].maxlen = 4096;
 }
 
-event_listenser::~event_listenser() {
+event_listener::~event_listener() {
     disconnect(mcsk_);
     close(stop_fd_);
 }
 
-void event_listenser::start_listening() {
+void event_listener::start_listening() {
     spdlog::info("listening for messages");
     int ep_fd = epoll_create1(0);
     if (ep_fd < 0) {
@@ -165,11 +165,11 @@ void event_listenser::start_listening() {
     delete[] ep_events;
 }
 
-void event_listenser::async_listen() {
-    listening_thread_ = std::thread(&event_listenser::start_listening, this);
+void event_listener::async_listen() {
+    listening_thread_ = std::thread(&event_listener::start_listening, this);
 }
 
-void event_listenser::stop_listening() {
+void event_listener::stop_listening() {
     uint64_t u = 1;
     [[maybe_unused]] auto _ = write(stop_fd_, &u, sizeof(u));
 
@@ -182,28 +182,28 @@ void event_listenser::stop_listening() {
     }
 }
 
-void event_listenser::set_handler(std::function<void(fs_event*)> handler) {
+void event_listener::set_handler(std::function<void(fs_event*)> handler) {
     handler_ = std::move(handler);
 }
 
-bool event_listenser::connect(nl_sock_ptr& sk) const {
+bool event_listener::connect(nl_sock_ptr& sk) const {
     sk = nl_socket_alloc();
     return sk ? genl_connect(sk) == 0 : false;
 }
 
-void event_listenser::disconnect(nl_sock_ptr& sk) const {
+void event_listener::disconnect(nl_sock_ptr& sk) const {
     nl_socket_free(sk);
 }
 
-bool event_listenser::set_callback(nl_sock_ptr& sk, nl_recvmsg_msg_cb_t func) {
+bool event_listener::set_callback(nl_sock_ptr& sk, nl_recvmsg_msg_cb_t func) {
     return nl_socket_modify_cb(sk, NL_CB_VALID, NL_CB_CUSTOM, func, this) == 0;
 }
 
-int event_listenser::get_fd(nl_sock_ptr& sk) const {
+int event_listener::get_fd(nl_sock_ptr& sk) const {
     return nl_socket_get_fd(sk);
 }
 
-void event_listenser::forward_event_to_handler(fs_event *event) const {
+void event_listener::forward_event_to_handler(fs_event *event) const {
     if (handler_) {
         std::invoke(handler_, event);
     }
@@ -227,7 +227,7 @@ fs_event* make_fs_event(uint8_t act,
     return event;
 }
 
-int event_listenser::event_handler(nl_msg_ptr msg, void* arg) {
+int event_listener::event_handler(nl_msg_ptr msg, void* arg) {
     nlattr* tb[VFSMONITOR_A_MAX + 1];
     int err = genlmsg_parse(nlmsg_hdr(msg), 0, tb, VFSMONITOR_A_MAX, vfs_policy);
     if (err < 0) {
@@ -252,8 +252,8 @@ int event_listenser::event_handler(nl_msg_ptr msg, void* arg) {
     }
 
     fs_event* event = make_fs_event(*act, *cookie, *major, *minor, *src, "");
-    auto listenser = static_cast<event_listenser*>(arg);
-    listenser->forward_event_to_handler(event);
+    auto listener = static_cast<event_listener*>(arg);
+    listener->forward_event_to_handler(event);
     return NL_OK;
 }
 

--- a/src/daemon/src/main.cpp
+++ b/src/daemon/src/main.cpp
@@ -104,8 +104,8 @@ int main(int argc, char* argv[]) {
     default_event_handler handler(event_handler_config);
     // default_event_handler 实例化时, 可能会清空索引目录, 这里重新设置 running 标志
     set_running_flag();
-    event_listenser listenser;
-    listenser.set_handler([&handler](fs_event *event) {
+    event_listener listener;
+    listener.set_handler([&handler](fs_event *event) {
         handler.handle(event);
     });
     config.set_config_change_handler([&handler, &config](std::string key) {
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
     QTimer timer;
     setup_kernel_module_alive_check(timer);
 
-    listenser.async_listen();
+    listener.async_listen();
     app.exec();
 
     // Clean up signal handlers
@@ -143,7 +143,7 @@ int main(int argc, char* argv[]) {
         g_source_remove(sigterm_id);
 
     spdlog::info("Performing cleanup tasks...");
-    listenser.stop_listening();
+    listener.stop_listening();
     handler.terminate_filter();
     handler.terminate_processing();
 

--- a/src/daemon/src/main.cpp
+++ b/src/daemon/src/main.cpp
@@ -100,11 +100,11 @@ int main(int argc, char* argv[]) {
     detect_last_time_quit_status();
     set_running_flag();
 
-    event_listenser listenser;
     print_event_handler_config(event_handler_config);
     default_event_handler handler(event_handler_config);
     // default_event_handler 实例化时, 可能会清空索引目录, 这里重新设置 running 标志
     set_running_flag();
+    event_listenser listenser;
     listenser.set_handler([&handler](fs_event *event) {
         handler.handle(event);
     });


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix daemon startup failure by correcting the event listener class and header name from `event_listenser` to `event_listener` across core, main, and public headers.