### PR TITLE
fix(server): cast __u64 to unsigned long long for format string

### DIFF
--- a/src/server/event-listener-mmap-ring.c
+++ b/src/server/event-listener-mmap-ring.c
@@ -94,7 +94,8 @@ static void ring_drain(MmapRingBackend *backend)
     if (dropped != backend->last_dropped) {
         __u64 delta = dropped - backend->last_dropped;
         backend->last_dropped = dropped;
-        g_warning("mmap-ring: dropped %llu events (ring full)", delta);
+        g_warning("mmap-ring: dropped %llu events (ring full)",
+                  (unsigned long long)delta);
     }
 }
 


### PR DESCRIPTION
__u64 is defined as unsigned long on mips64el, causing -Werror=format= when printed with %llu. Cast explicitly to match the format specifier across all architectures.

将 __u64 显式转换为 unsigned long long 以匹配 %llu 格式符,修复
mips64el 架构上 __u64 为 unsigned long 导致的格式化类型不匹配错误。

Log: 修复 __u64 格式化类型不匹配的构建错误
PMS: BUG-370779, BUG-370781
Influence: 修复 mips64el 架构上的构建失败,不影响功能逻辑。

## Summary by Sourcery

Bug Fixes:
- Resolve -Werror=format build failures on mips64el by casting __u64 values to unsigned long long when using the %llu format specifier in mmap-ring warning logs.