### PR TITLE
fix(daemon): ensure daemon exit within 3 seconds via TimeoutStopSec

### DIFF
--- a/src/daemon/deepin-anything-daemon.service
+++ b/src/daemon/deepin-anything-daemon.service
@@ -6,5 +6,6 @@ After=udisks2.service
 ExecStart=/usr/libexec/deepin-anything-daemon
 Restart=on-failure
 RestartSec=30
+TimeoutStopSec=3
 MemoryHigh=2G
 MemoryMax=3G


### PR DESCRIPTION
## 根因分析

关机时 deepin-anything-server 先于 daemon 停止，dispatcher socket 被移除。daemon 检测到断连后触发提交 `117c9ae` 引入的"延迟退出"逻辑（每 3s 检查 socket inode 是否变化，最多 10 次共 30s），关机时 socket 永久消失，daemon 等满 30s 后以退出码 1 退出，再触发 systemd `Restart=on-failure` + `RestartSec=30` 的无效重启（D-Bus 关闭阶段失败），合计约 60s 拖延重启等待。

关键证据：
- `src/daemon/src/core/event_listener.cpp:16-17,51-77` — 重启检查定时器 `10 × 3000ms = 30s`，关机时 inode 变化条件恒假。
- `src/daemon/src/main.cpp:23-28` — `on_quit_requested` 无条件 `set_app_restart(true)`，关机也以退出码 1 退出。
- `src/daemon/deepin-anything-daemon.service:7-8` — `Restart=on-failure` + `RestartSec=30`。
- 两份架构日志（x86 `boot3_log.txt`、arm `boot1_log-arm.txt`）时间线一致：断连 → 等 30s 自行退出 → 30s 后重启失败，合计约 60s。

## 修复方案

daemon 存在一定概率在 stop 后没有按预期执行退出逻辑。作为兜底，在 `deepin-anything-daemon.service` 的 `[Service]` 段新增 `TimeoutStopSec=3`，确保 daemon 在 3 秒内退出。该 systemd 级别兜底不依赖 daemon 内部退出逻辑的可靠性，已由维护者实测验证有效。

## 改动安全评估

低风险。仅新增一行服务配置，不改动代码签名/逻辑/接口，无代码调用者；非正常强杀可由 daemon 现有 `running_flag` / `detect_last_time_quit_status` 机制恢复。详见 `change-safety.md`。

## Summary by Sourcery

Enhancements:
- Configure the deepin-anything-daemon systemd service with a 3-second TimeoutStopSec to bound shutdown latency and avoid prolonged restart loops.