### PR TITLE
fix(daemon): ensure daemon exit within 3 seconds via TimeoutStopSec

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-anything (7.0.49) unstable; urgency=medium
+
+  * fix(daemon): ensure daemon exit within 3 seconds via TimeoutStopSec
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 06 Aug 2026 14:34:57 +0800
+
 deepin-anything (7.0.48) unstable; urgency=medium
 
   * fix(kernelmod): add missing parentheses in cmp_event_path macro

--- a/src/daemon/deepin-anything-daemon.service
+++ b/src/daemon/deepin-anything-daemon.service
@@ -6,5 +6,6 @@ After=udisks2.service
 ExecStart=/usr/libexec/deepin-anything-daemon
 Restart=on-failure
 RestartSec=30
+TimeoutStopSec=3
 MemoryHigh=2G
 MemoryMax=3G


### PR DESCRIPTION
## Summary by Sourcery

Adjust systemd service configuration to enforce daemon shutdown within a bounded timeout and update Debian packaging changelog accordingly.

Bug Fixes:
- Ensure the daemon process exits within three seconds by configuring the systemd service stop timeout.

Chores:
- Update Debian changelog entries to reflect the daemon shutdown timeout change.