### PR TITLE
fix(event-listener): attach fd/timer sources to thread-local context

### DIFF
--- a/src/daemon/src/core/event_listener.cpp
+++ b/src/daemon/src/core/event_listener.cpp
@@ -85,10 +85,19 @@ static void start_restart_check(EventListener *listener)
         listener->initial_sock_inode = st.st_ino;
 
     listener->timer_check_count = 0;
-    listener->timer_source_id = g_timeout_add(RESTART_CHECK_INTERVAL_MS,
-                                              on_restart_check, listener);
-    if (listener->timer_source_id == 0) {
+
+    GSource *timer_source = g_timeout_source_new(RESTART_CHECK_INTERVAL_MS);
+    if (timer_source == NULL) {
         spdlog::warn("Failed to create restart check timer, quitting immediately");
+        notify_quit(listener);
+        return;
+    }
+    g_source_set_callback(timer_source, on_restart_check, listener, NULL);
+    listener->timer_source_id = g_source_attach(timer_source, listener->context);
+    g_source_unref(timer_source);
+
+    if (listener->timer_source_id == 0) {
+        spdlog::warn("Failed to attach restart check timer, quitting immediately");
         notify_quit(listener);
     } else {
         spdlog::info("Waiting for dispatcher restart (checking every {}ms, "
@@ -179,14 +188,24 @@ static gpointer event_listener_thread_func(gpointer data)
         goto cleanup;
     }
 
-    listener->fd_source_id = g_unix_fd_add_full(
-        G_PRIORITY_DEFAULT, sock_fd,
-        (GIOCondition)(G_IO_IN | G_IO_HUP | G_IO_ERR),
-        on_fd_readable, listener, NULL);
-    if (listener->fd_source_id == 0) {
-        spdlog::error("Failed to add fd watch for receiver socket");
-        signal_startup(listener, FALSE);
-        goto cleanup;
+    {
+        GSource *fd_source = g_unix_fd_source_new(sock_fd,
+            (GIOCondition)(G_IO_IN | G_IO_HUP | G_IO_ERR));
+        if (fd_source == NULL) {
+            spdlog::error("Failed to create fd watch source for receiver socket");
+            signal_startup(listener, FALSE);
+            goto cleanup;
+        }
+        g_source_set_priority(fd_source, G_PRIORITY_DEFAULT);
+        g_source_set_callback(fd_source,
+            (GSourceFunc)(void (*)(void))on_fd_readable, listener, NULL);
+        listener->fd_source_id = g_source_attach(fd_source, listener->context);
+        g_source_unref(fd_source);
+        if (listener->fd_source_id == 0) {
+            spdlog::error("Failed to attach fd watch to listener context");
+            signal_startup(listener, FALSE);
+            goto cleanup;
+        }
     }
 
     spdlog::info("Event listener thread started");


### PR DESCRIPTION
Replace g_unix_fd_add_full/g_timeout_add with explicit source creation and g_source_attach to the listener's dedicated GMainContext.

将 fd 与定时器源显式附加到监听线程私有的 GMainContext，避免
误挂到主线程默认上下文导致事件循环混乱与信号派发受阻。

Log: 修复事件源挂载到错误上下文的问题
PMS: BUG-372731
Influence: 监听线程的 fd 与重启检查定时器源不再污染主线程默认上下文，独立事件循环按预期工作，主线程信号源派发不受干扰。

## Summary by Sourcery

Attach event listener timer and fd sources explicitly to the listener thread’s GMainContext to avoid misregistration on the default main loop.

Bug Fixes:
- Ensure restart check timer sources are created and attached to the listener’s dedicated main context instead of the default context.
- Ensure socket fd watch sources are created and attached to the listener’s dedicated main context, preventing interference with the main thread’s event loop.
- Add error handling for failures when creating or attaching restart timer and fd watch sources, triggering orderly shutdown or startup failure signaling.