### PR TITLE
chore: Bump version to 7.0.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-anything (7.0.60) unstable; urgency=medium
+
+  * fix(daemon): ensure daemon exit within 3 seconds via TimeoutStopSec
+  * fix(event-listener): attach fd/timer sources to thread-local context
+  * test: add server/daemon stop-start stress test script
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 06 Aug 2026 21:34:19 +0800
+
 deepin-anything (7.0.46) unstable; urgency=medium
 
   * fix(event-listener): delay quit on disconnect to detect server


### PR DESCRIPTION
As title.

Log: Bump version to 7.0.60

## Summary by Sourcery

Chores:
- Update Debian changelog entry for version 7.0.60.