### PR TITLE
feat(server): add EventSource_MMAP backend for vfs event listening

### DIFF
--- a/src/server/backend/anythingbackend.cpp
+++ b/src/server/backend/anythingbackend.cpp
@@ -1,19 +1,19 @@
-// Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-
-#include <signal.h>
-#include <sys/utsname.h>
-
-#include <QDBusConnection>
 
 #include "anythingbackend.h"
 #include "anythingexport.h"
 #include "server.h"
 #include "eventsource_genl.h"
+#include "eventsource_mmap.h"
 #include "logdefine.h"
 #include "logsaver.h"
+#include <QDBusConnection>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #include "lftmanager.h"
 #include "anything_adaptor.h"
@@ -78,10 +78,25 @@ int AnythingBackend::init_connection()noexcept
     return -1;
 }
 
+static EventSource *createEventSource()
+{
+    /* Prefer the mmap-ring transport when the kernel char-device is
+     * available; fall back to generic netlink otherwise. */
+    struct stat st;
+    if (stat("/dev/vfs_monitor", &st) == 0 && S_ISCHR(st.st_mode)) {
+        EventSource *mmap_src = new EventSource_MMAP();
+        if (mmap_src->init())
+            return mmap_src;
+        nInfo("mmap transport init failed, fallback to genl.");
+        delete mmap_src;
+    }
+    return new EventSource_GENL();
+}
+
 int AnythingBackend::monitorStart()
 {
     if (!eventsrc)
-        eventsrc = new EventSource_GENL();
+        eventsrc = createEventSource();
 
     if (!eventsrc->isInited() && !eventsrc->init())
         return -1;

--- a/src/server/backend/anythingbackend.h
+++ b/src/server/backend/anythingbackend.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,12 +6,12 @@
 #define ANYTHINGBACKEND_H
 
 #include "dasdefine.h"
+#include "eventsource.h"
 #include <QObject>
 
 DAS_BEGIN_NAMESPACE
 
 class Server;
-class EventSource_GENL;
 class AnythingBackend : public QObject
 {
     Q_OBJECT
@@ -29,7 +28,7 @@ private:
 
     Server *server = nullptr;
     bool hasconnected = false;
-    EventSource_GENL *eventsrc = nullptr;
+    EventSource *eventsrc = nullptr;
 };
 
 DAS_END_NAMESPACE

--- a/src/server/backend/eventsource_genl.cpp
+++ b/src/server/backend/eventsource_genl.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,14 +6,11 @@
 #include "vfs_change_consts.h"
 #include "logdefine.h"
 #include "vfs_genl.h"
-#include "mountcacher.h"
 
 #include <sys/sysmacros.h>
 #include <netlink/genl/genl.h>
 #include <netlink/genl/ctrl.h>
 #include <errno.h>
-#include <QString>
-#include <QFile>
 
 DAS_BEGIN_NAMESPACE
 
@@ -44,7 +40,6 @@ EventSource_GENL::EventSource_GENL()
 
     nlsock = nullptr;
     cb = nl_cb_alloc(NL_CB_DEFAULT);
-    updatePartitions();
 
     buf[0] = 0;
     new_msg = false;
@@ -136,109 +131,6 @@ bool EventSource_GENL::getEvent(unsigned char *type, char **src, char **dst, boo
     }
 }
 
-#define MKDEV(ma,mi)    ((ma)<<8 | (mi))
-
-
-void write_vfs_unnamed_device(const char *str)
-{
-    QString path("/sys/kernel/vfs_monitor/vfs_unnamed_devices");
-    QFile file(path);
-    if (!file.open(QIODevice::WriteOnly)) {
-        QByteArray ba = path.toLatin1();
-        nWarning("open file failed: %s.", ba.data());
-        return;
-    }
-    file.write(str, strlen(str));
-    file.close();
-}
-
-void read_vfs_unnamed_device(QSet<QByteArray> &devices)
-{
-    QString path("/sys/kernel/vfs_monitor/vfs_unnamed_devices");
-    QFile file(path);
-    if (!file.open(QIODevice::ReadOnly)) {
-        QByteArray ba = path.toLatin1();
-        nWarning("open file failed: %s.", ba.data());
-        return;
-    }
-    QByteArray line = file.readLine();
-    file.close();
-    
-    /* remove last \n */
-    line.chop(1);
-    QList<QByteArray> list = line.split(',');
-    foreach (const QByteArray &minor, list) {
-        devices.insert(minor);
-    }
-}
-
-void update_vfs_unnamed_device(const QSet<QByteArray> &news)
-{
-    char buf[32];
-    QSet<QByteArray> olds;
-    read_vfs_unnamed_device(olds);
-
-    QSet<QByteArray> removes(olds);
-    removes.subtract(news);
-    foreach (const QByteArray &minor, removes) {
-        snprintf(buf, sizeof(buf), "r%s", minor.data());
-        write_vfs_unnamed_device(buf);
-    }
-
-    QSet<QByteArray> adds(news);
-    adds.subtract(olds);
-    foreach (const QByteArray &minor, adds) {
-        snprintf(buf, sizeof(buf), "a%s", minor.data());
-        write_vfs_unnamed_device(buf);
-    }
-}
-
-void EventSource_GENL::updatePartitions()
-{
-    /* Invokes updateMountPoints in the event loop of MountCacher to avoid multi-threaded access */
-    QMetaObject::invokeMethod(MountCacher::instance(), "updateMountPoints", Qt::QueuedConnection);
-
-    /*
-     * No use`MountCacher::instance()->getMountPointsByRoot("/")` to get mount list.
-     * This is to avoid multi-threaded access, and locks may cause dead locks.
-     */
-    QString file_mountinfo_path("/proc/self/mountinfo");
-    QFile file_mountinfo(file_mountinfo_path);
-    if (!file_mountinfo.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        QByteArray ba = file_mountinfo_path.toLatin1();
-        nWarning("open file failed: %s.", ba.data());
-        return;
-    }
-    QByteArray mount_info;
-    mount_info = file_mountinfo.readAll();
-    file_mountinfo.close();
-
-    unsigned int major, minor;
-    char mp[256], root[256], type[256], *line = mount_info.data();
-    QSet<QByteArray> dlnfs_devs;
-    QByteArray ba;
-    partitions.clear();
-    nInfo("updatePartitions start.");
-    while (sscanf(line, "%*d %*d %u:%u %250s %250s %*s %*s %*s %250s %*s %*s\n", &major, &minor, root, mp, type) == 5) {
-        line = strchr(line, '\n') + 1;
-
-        if (!major && strcmp(type, "fuse.dlnfs"))
-            continue;
-
-        if (!strcmp(root, "/")) {
-            partitions.insert(MKDEV(major, minor), QByteArray(mp));
-            nInfo("%u:%u, %s", major, minor, mp);
-            /* add monitoring for dlnfs device */
-            if (!major && !strcmp(type, "fuse.dlnfs")) {
-                ba.setNum(minor);
-                dlnfs_devs.insert(ba);
-            }
-        }
-    }
-    update_vfs_unnamed_device(dlnfs_devs);
-    nInfo("updatePartitions end.");
-}
-
 int EventSource_GENL::handleMsg(struct nl_msg *msg, void* arg)
 {
     EventSource_GENL *event_src = static_cast<EventSource_GENL*>(arg);
@@ -276,11 +168,11 @@ int EventSource_GENL::handleMsg(struct nl_msg *msg)
     get_attr(attrs, VFSMONITOR_A_PATH, _src, string);
 
     if (_act < ACT_MOUNT) {
-        if (!partitions.contains(MKDEV(major, minor))) {
+        if (!partitions.contains(major, minor)) {
             nWarning("unknown device, %u, dev: %u:%u, path: %s, cookie: %u.", _act, major, minor, _src, _cookie);
             return 0;
         }
-        _root = partitions[MKDEV(major, minor)].data();
+        _root = const_cast<char*>(partitions.rootFor(major, minor));
         if (strcmp(_root, "/") == 0)
             _root = nullptr;
     }
@@ -308,7 +200,7 @@ int EventSource_GENL::handleMsg(struct nl_msg *msg)
         break;
     case ACT_MOUNT:
     case ACT_UNMOUNT:
-        updatePartitions();
+        partitions.updatePartitions();
         return 0;
     case ACT_RENAME_FILE:
     case ACT_RENAME_FOLDER:

--- a/src/server/backend/eventsource_genl.h
+++ b/src/server/backend/eventsource_genl.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2021 UOS Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +9,7 @@
 #include <QByteArray>
 #include "dasdefine.h"
 #include "eventsource.h"
+#include "partitionmonitor.h"
 
 struct nl_msg;
 struct nl_sock;
@@ -28,7 +28,6 @@ public:
     bool getEvent(unsigned char *type, char **src, char **dst, bool *end) override;
 
 private:
-    void updatePartitions();
     static int handleMsg(struct nl_msg *msg, void* arg);
     int handleMsg(struct nl_msg *msg);
 
@@ -40,7 +39,7 @@ private:
     struct nl_sock *nlsock;
     struct nl_cb *cb;
     QMap<unsigned int, QByteArray> rename_from;
-    QMap<unsigned int, QByteArray> partitions;
+    PartitionMonitor partitions;
 
     char buf[4096*2];
     bool new_msg;

--- a/src/server/backend/eventsource_mmap.cpp
+++ b/src/server/backend/eventsource_mmap.cpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "eventsource_mmap.h"
+#include "vfs_change_consts.h"
+#include "vfs_ringbuf_uapi.h"
+#include "logdefine.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+DAS_BEGIN_NAMESPACE
+
+Q_LOGGING_CATEGORY(logM, "anything.normal.mmap", DEFAULT_MSG_TYPE)
+
+#define DENTRY_DEV_PATH "/dev/vfs_monitor"
+
+EventSource_MMAP::EventSource_MMAP()
+{
+    inited = false;
+
+    fd = -1;
+    mem = nullptr;
+    map_size = 0;
+    hdr = nullptr;
+    ring_slots = nullptr;
+    record_size = 0;
+    capacity = 0;
+    last_dropped = 0;
+
+    buf[0] = 0;
+    act = (unsigned char)-1;
+    dst = nullptr;
+}
+
+EventSource_MMAP::~EventSource_MMAP()
+{
+    if (mem) {
+        munmap(mem, map_size);
+        mem = nullptr;
+        hdr = nullptr;
+        ring_slots = nullptr;
+    }
+
+    if (fd >= 0) {
+        close(fd);
+        fd = -1;
+    }
+}
+
+bool EventSource_MMAP::init()
+{
+    if (inited)
+        return true;
+
+    fd = open(DENTRY_DEV_PATH, O_RDWR | O_NONBLOCK);
+    if (fd < 0) {
+        nWarning("open %s fail: %s.", DENTRY_DEV_PATH, strerror(errno));
+        return false;
+    }
+
+    record_size = sizeof(struct vfs_ringbuf_dentry_rec);
+    size_t header_size = sizeof(struct vfs_ringbuf_header);
+    map_size = header_size + (size_t)VFS_RINGBUF_CAPACITY * record_size;
+
+    mem = mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mem == MAP_FAILED) {
+        nWarning("mmap %s fail: %s.", DENTRY_DEV_PATH, strerror(errno));
+        mem = nullptr;
+        close(fd);
+        fd = -1;
+        return false;
+    }
+
+    hdr = static_cast<struct vfs_ringbuf_header *>(mem);
+    ring_slots = static_cast<const char *>(mem) + header_size;
+    capacity = VFS_RINGBUF_CAPACITY;
+
+    if (hdr->magic != VFS_RINGBUF_MAGIC) {
+        nWarning("mmap %s: bad magic 0x%08x.", DENTRY_DEV_PATH, hdr->magic);
+        munmap(mem, map_size);
+        mem = nullptr;
+        hdr = nullptr;
+        ring_slots = nullptr;
+        close(fd);
+        fd = -1;
+        return false;
+    }
+
+    if (hdr->record_size != record_size) {
+        nWarning("mmap %s: record_size mismatch (kernel=%u, user=%u).",
+                 DENTRY_DEV_PATH, hdr->record_size, record_size);
+        munmap(mem, map_size);
+        mem = nullptr;
+        hdr = nullptr;
+        ring_slots = nullptr;
+        close(fd);
+        fd = -1;
+        return false;
+    }
+
+    /* Trust the kernel-reported capacity (power of two). */
+    capacity = hdr->capacity;
+    last_dropped = hdr->dropped_count;
+
+    inited = true;
+    nInfo("mmap event source inited (fd=%d, map=%zu, capacity=%u).",
+          fd, map_size, capacity);
+    return true;
+}
+
+bool EventSource_MMAP::isInited()
+{
+    return inited;
+}
+
+bool EventSource_MMAP::getEvent(unsigned char *type, char **src, char **dst, bool *end)
+{
+    while (true) {
+        switch (drainOne()) {
+        case DrainGotEvent:
+            *type = act;
+            *src = buf;
+            *dst = this->dst;
+            *end = true;
+            return true;
+        case DrainSkipped:
+            /* Record consumed but no deliverable event produced — the
+             * ring may still hold more, loop and try the next one. */
+            continue;
+        case DrainEmpty:
+            break; /* fall through to poll() */
+        }
+
+        /* Ring empty — block on poll() until the kernel wakes us. */
+        struct pollfd pfd;
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+
+        int ret = poll(&pfd, 1, -1);
+        if (ret < 0) {
+            if (errno == EINTR)
+                continue;
+            nWarning("poll fail: %s.", strerror(errno));
+            return false;
+        }
+        if (pfd.revents & (POLLHUP | POLLERR)) {
+            nWarning("mmap channel closed (revents=0x%x).", pfd.revents);
+            return false;
+        }
+        /* POLLIN: the kernel published new records — loop and drain. */
+    }
+}
+
+EventSource_MMAP::DrainResult EventSource_MMAP::drainOne()
+{
+    __u64 head = __atomic_load_n(&hdr->producer_head, __ATOMIC_ACQUIRE);
+    __u64 tail = __atomic_load_n(&hdr->consumer_tail, __ATOMIC_ACQUIRE);
+
+    if (head == tail) {
+        /* Report dropped events (newest, discarded while the ring was full). */
+        __u64 dropped = __atomic_load_n(&hdr->dropped_count, __ATOMIC_ACQUIRE);
+        if (dropped != last_dropped) {
+            __u64 delta = dropped - last_dropped;
+            last_dropped = dropped;
+            nWarning("mmap-ring dropped %llu events (ring full).",
+                     (unsigned long long)delta);
+        }
+        return DrainEmpty;
+    }
+
+    __u32 slot = (__u32)(tail & (capacity - 1));
+    const struct vfs_ringbuf_dentry_rec *rec =
+        reinterpret_cast<const struct vfs_ringbuf_dentry_rec *>(
+            ring_slots + (size_t)slot * record_size);
+
+    unsigned char _act = rec->action;
+    unsigned int _cookie = rec->cookie;
+    unsigned short major = rec->major;
+    unsigned char minor = rec->minor;
+
+    /* Copy the path out of the ring slot BEFORE advancing consumer_tail.
+     * Once the tail is released the kernel producer may immediately
+     * reclaim this slot and overwrite rec->path — any subsequent use of
+     * a pointer into the slot (partitions check, rename stash, saveData)
+     * would race with the producer and could observe a half-written path.
+     * Scalar fields above are already safe: they were read before the
+     * release and stored in locals. */
+    char _path_buf[sizeof(rec->path)];
+    __u32 _path_len = rec->path_len;
+    if (_path_len >= sizeof(_path_buf))
+        _path_len = sizeof(_path_buf) - 1;
+    memcpy(_path_buf, rec->path, _path_len);
+    _path_buf[_path_len] = '\0';
+    char *_src = _path_buf;
+
+    /* Advance the tail — the slot is now reclaimable by the producer. */
+    __atomic_store_n(&hdr->consumer_tail, tail + 1, __ATOMIC_RELEASE);
+
+    char *_root = nullptr;
+
+    if (_act < ACT_MOUNT) {
+        if (!partitions.contains(major, minor)) {
+            nWarning("unknown device, %u, dev: %u:%u, path: %s, cookie: %u.",
+                     _act, major, minor, _src, _cookie);
+            return DrainSkipped;
+        }
+        _root = const_cast<char *>(partitions.rootFor(major, minor));
+        if (strcmp(_root, "/") == 0)
+            _root = nullptr;
+    }
+
+    char *_dst = nullptr;
+    switch (_act) {
+    case ACT_NEW_FILE:
+    case ACT_NEW_SYMLINK:
+    case ACT_NEW_LINK:
+    case ACT_NEW_FOLDER:
+    case ACT_DEL_FILE:
+    case ACT_DEL_FOLDER:
+        _dst = nullptr;
+        break;
+    case ACT_RENAME_FROM_FILE:
+    case ACT_RENAME_FROM_FOLDER:
+        rename_from.insert(_cookie, QByteArray(_src));
+        return DrainSkipped;
+    case ACT_RENAME_TO_FILE:
+    case ACT_RENAME_TO_FOLDER:
+        if (rename_from.contains(_cookie)) {
+            _act = _act == ACT_RENAME_TO_FILE ? ACT_RENAME_FILE : ACT_RENAME_FOLDER;
+            _dst = _src;
+            _src = rename_from[_cookie].data();
+        }
+        break;
+    case ACT_MOUNT:
+    case ACT_UNMOUNT:
+        partitions.updatePartitions();
+        return DrainSkipped;
+    case ACT_RENAME_FILE:
+    case ACT_RENAME_FOLDER:
+        nWarning("not support file action: %d.", int(_act));
+        return DrainSkipped;
+    default:
+        nWarning("unknow file action: %d.", int(_act));
+        return DrainSkipped;
+    }
+
+    bool ok = saveData(_act, _root, _src, _dst);
+
+    if (_act == ACT_RENAME_FILE || _act == ACT_RENAME_FOLDER)
+        rename_from.remove(_cookie);
+
+    return ok ? DrainGotEvent : DrainSkipped;
+}
+
+bool EventSource_MMAP::saveData(unsigned char _act, char *_root, char *_src, char *_dst)
+{
+    size_t root_size = _root ? strlen(_root) : 0;
+    size_t src_size = strlen(_src);
+
+    if (_dst) {
+        size_t dst_size = strlen(_dst);
+        if (root_size * 2 + src_size + dst_size + 2 > sizeof(buf)) {
+            nCritical("the msg buf is too small to cache msg.");
+            return false;
+        }
+    } else {
+        if (root_size + src_size + 1 > sizeof(buf)) {
+            nCritical("the msg buf is too small to cache msg.");
+            return false;
+        }
+    }
+
+    act = _act;
+
+    /* save src */
+    if (_root)
+        strcpy(buf, _root);
+    strcpy(buf + root_size, _src);
+
+    /* save dst */
+    if (_dst) {
+        dst = buf + root_size + src_size + 1;
+        if (_root)
+            strcpy(dst, _root);
+        strcpy(dst + root_size, _dst);
+    } else {
+        dst = nullptr;
+    }
+
+    return true;
+}
+
+DAS_END_NAMESPACE

--- a/src/server/backend/eventsource_mmap.h
+++ b/src/server/backend/eventsource_mmap.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef EVENTSOURCE_MMAP_H
+#define EVENTSOURCE_MMAP_H
+
+#include <QMap>
+#include <QByteArray>
+#include "dasdefine.h"
+#include "eventsource.h"
+#include "partitionmonitor.h"
+
+struct vfs_ringbuf_header;
+struct vfs_ringbuf_dentry_rec;
+
+DAS_BEGIN_NAMESPACE
+
+/*
+ * EventSource_MMAP — mmap-ring based VFS event source.
+ *
+ * Functionally equivalent to EventSource_GENL: it consumes VFS events
+ * produced by the kernel module through a shared, lock-free ring buffer
+ * exposed via /dev/vfs_monitor. The ring layout and SPSC contract are
+ * defined in vfs_ringbuf_uapi.h.
+ *
+ * Unlike the standalone C backend (event-listener-mmap-ring.c) which
+ * spawns a dedicated thread driven by a GLib main loop, this class
+ * implements the synchronous EventSource interface: getEvent() blocks
+ * on poll() and drains records one at a time until a deliverable event
+ * is produced. No extra thread, no GLib event loop, no g_unix_fd_add.
+ */
+class EventSource_MMAP : public EventSource
+{
+public:
+    EventSource_MMAP();
+    ~EventSource_MMAP() override;
+
+    bool init() override;
+    bool isInited() override;
+    bool getEvent(unsigned char *type, char **src, char **dst, bool *end) override;
+
+private:
+    /* Outcome of draining a single record from the ring. */
+    enum DrainResult {
+        DrainGotEvent,   /* a deliverable event is ready in buf/act/dst */
+        DrainSkipped,     /* record consumed but no event produced
+                           * (mount/unmount, rename_from stash, …) —
+                           * the ring may still hold more, try again. */
+        DrainEmpty,       /* ring is empty — block on poll(). */
+    };
+
+    /* Drain one record from the ring and apply the same post-processing
+     * (partition root prefix, rename_from matching, mount/unmount
+     * handling) as EventSource_GENL::handleMsg. */
+    DrainResult drainOne();
+
+    bool saveData(unsigned char _act, char *_root, char *_src, char *_dst);
+
+private:
+    bool inited;
+
+    int fd;
+    void *mem;
+    size_t map_size;
+    struct vfs_ringbuf_header *hdr;
+    const char *ring_slots;
+    quint32 record_size;
+    quint32 capacity;
+    quint64 last_dropped;
+
+    PartitionMonitor partitions;
+    QMap<unsigned int, QByteArray> rename_from;
+
+    char buf[4096 * 2];
+    unsigned char act;
+    char *dst;
+};
+
+DAS_END_NAMESPACE
+
+#endif // EVENTSOURCE_MMAP_H

--- a/src/server/backend/lib/partitionmonitor.cpp
+++ b/src/server/backend/lib/partitionmonitor.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "partitionmonitor.h"
+#include "logdefine.h"
+#include "mountcacher.h"
+
+#include <QFile>
+#include <QString>
+
+DAS_BEGIN_NAMESPACE
+
+PartitionMonitor::PartitionMonitor()
+{
+    updatePartitions();
+}
+
+void PartitionMonitor::updatePartitions()
+{
+    /* Invokes updateMountPoints in the event loop of MountCacher to avoid multi-threaded access */
+    QMetaObject::invokeMethod(MountCacher::instance(), "updateMountPoints", Qt::QueuedConnection);
+
+    /*
+     * No use`MountCacher::instance()->getMountPointsByRoot("/")` to get mount list.
+     * This is to avoid multi-threaded access, and locks may cause dead locks.
+     */
+    QString file_mountinfo_path("/proc/self/mountinfo");
+    QFile file_mountinfo(file_mountinfo_path);
+    if (!file_mountinfo.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QByteArray ba = file_mountinfo_path.toLatin1();
+        nWarning("open file failed: %s.", ba.data());
+        return;
+    }
+    QByteArray mount_info;
+    mount_info = file_mountinfo.readAll();
+    file_mountinfo.close();
+
+    unsigned int major, minor;
+    char mp[256], root[256], type[256], *line = mount_info.data();
+    QSet<QByteArray> dlnfs_devs;
+    QByteArray ba;
+    partitions.clear();
+    nInfo("updatePartitions start.");
+    while (sscanf(line, "%*d %*d %u:%u %250s %250s %*s %*s %*s %250s %*s %*s\n", &major, &minor, root, mp, type) == 5) {
+        line = strchr(line, '\n') + 1;
+
+        if (!major && strcmp(type, "fuse.dlnfs"))
+            continue;
+
+        if (!strcmp(root, "/")) {
+            partitions.insert(partition_mkdev(major, minor), QByteArray(mp));
+            nInfo("%u:%u, %s", major, minor, mp);
+            /* add monitoring for dlnfs device */
+            if (!major && !strcmp(type, "fuse.dlnfs")) {
+                ba.setNum(minor);
+                dlnfs_devs.insert(ba);
+            }
+        }
+    }
+    update_vfs_unnamed_device(dlnfs_devs);
+    nInfo("updatePartitions end.");
+}
+
+bool PartitionMonitor::contains(unsigned int major, unsigned int minor) const
+{
+    return partitions.contains(partition_mkdev(major, minor));
+}
+
+const char *PartitionMonitor::rootFor(unsigned int major, unsigned int minor) const
+{
+    auto it = partitions.find(partition_mkdev(major, minor));
+    return it != partitions.end() ? it->constData() : nullptr;
+}
+
+void write_vfs_unnamed_device(const char *str)
+{
+    QString path("/sys/kernel/vfs_monitor/vfs_unnamed_devices");
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        QByteArray ba = path.toLatin1();
+        nWarning("open file failed: %s.", ba.data());
+        return;
+    }
+    file.write(str, strlen(str));
+    file.close();
+}
+
+void read_vfs_unnamed_device(QSet<QByteArray> &devices)
+{
+    QString path("/sys/kernel/vfs_monitor/vfs_unnamed_devices");
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QByteArray ba = path.toLatin1();
+        nWarning("open file failed: %s.", ba.data());
+        return;
+    }
+    QByteArray line = file.readLine();
+    file.close();
+
+    /* remove last \n */
+    line.chop(1);
+    QList<QByteArray> list = line.split(',');
+    foreach (const QByteArray &minor, list) {
+        devices.insert(minor);
+    }
+}
+
+void update_vfs_unnamed_device(const QSet<QByteArray> &news)
+{
+    char buf[32];
+    QSet<QByteArray> olds;
+    read_vfs_unnamed_device(olds);
+
+    QSet<QByteArray> removes(olds);
+    removes.subtract(news);
+    foreach (const QByteArray &minor, removes) {
+        snprintf(buf, sizeof(buf), "r%s", minor.data());
+        write_vfs_unnamed_device(buf);
+    }
+
+    QSet<QByteArray> adds(news);
+    adds.subtract(olds);
+    foreach (const QByteArray &minor, adds) {
+        snprintf(buf, sizeof(buf), "a%s", minor.data());
+        write_vfs_unnamed_device(buf);
+    }
+}
+
+DAS_END_NAMESPACE

--- a/src/server/backend/lib/partitionmonitor.cpp
+++ b/src/server/backend/lib/partitionmonitor.cpp
@@ -42,8 +42,10 @@ void PartitionMonitor::updatePartitions()
     QByteArray ba;
     partitions.clear();
     nInfo("updatePartitions start.");
-    while (sscanf(line, "%*d %*d %u:%u %250s %250s %*s %*s %*s %250s %*s %*s\n", &major, &minor, root, mp, type) == 5) {
-        line = strchr(line, '\n') + 1;
+    while (line && sscanf(line, "%*d %*d %u:%u %250s %250s %*s %*s %*s %250s %*s %*s\n", &major, &minor, root, mp, type) == 5) {
+        line = strchr(line, '\n');
+        if (line)
+            ++line;
 
         if (!major && strcmp(type, "fuse.dlnfs"))
             continue;

--- a/src/server/backend/lib/partitionmonitor.h
+++ b/src/server/backend/lib/partitionmonitor.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PARTITIONMONITOR_H
+#define PARTITIONMONITOR_H
+
+#include "dasdefine.h"
+
+#include <QByteArray>
+#include <QMap>
+#include <QSet>
+
+DAS_BEGIN_NAMESPACE
+
+/**
+ * Encodes a (major, minor) device pair into the key used by the partition map.
+ * Keep this in sync with the kernel's encoding of dev_t in mountinfo (the
+ * value read from /proc/self/mountinfo is already in the major:minor form
+ * shown there, but the map collapses the pair into a single unsigned int).
+ */
+static inline unsigned int partition_mkdev(unsigned int major, unsigned int minor)
+{
+    return (major << 8) | minor;
+}
+
+/**
+ * PartitionMonitor owns the partition map derived from /proc/self/mountinfo
+ * and the unnamed-device list kept in sync with the kernel via
+ * /sys/kernel/vfs_monitor/vfs_unnamed_devices.
+ *
+ * These duties were previously embedded in EventSource_GENL.  Lifting them
+ * into a standalone class lets any EventSource implementation (genl, fanotify,
+ * ...) share the same partition resolution and unnamed-device bookkeeping.
+ */
+class PartitionMonitor
+{
+public:
+    PartitionMonitor();
+
+    /** Re-read /proc/self/mountinfo and rebuild the partition map. */
+    void updatePartitions();
+
+    /** Whether (major,minor) is tracked as a watched partition. */
+    bool contains(unsigned int major, unsigned int minor) const;
+
+    /** Root mount point for the given device key, or nullptr if unknown. */
+    const char *rootFor(unsigned int major, unsigned int minor) const;
+
+private:
+    QMap<unsigned int, QByteArray> partitions;
+};
+
+/* --- unnamed-device helpers (used by updatePartitions) --- */
+
+void write_vfs_unnamed_device(const char *str);
+void read_vfs_unnamed_device(QSet<QByteArray> &devices);
+void update_vfs_unnamed_device(const QSet<QByteArray> &news);
+
+DAS_END_NAMESPACE
+
+#endif // PARTITIONMONITOR_H


### PR DESCRIPTION
## Summary by Sourcery

Introduce an mmap-based VFS event source backend and refactor partition monitoring so both backends share the same device and mount tracking logic.

New Features:
- Add EventSource_MMAP backend that reads VFS events via a shared ring buffer exposed by /dev/vfs_monitor.
- Select between mmap-based and generic netlink event sources at runtime based on availability of the kernel char device.

Enhancements:
- Refactor partition and unnamed-device tracking into a reusable PartitionMonitor class shared by event sources.
- Update AnythingBackend to depend on the abstract EventSource interface instead of the GENL-specific implementation.
- Simplify EventSource_GENL by delegating partition handling to PartitionMonitor and removing duplicate unnamed-device helpers.
- Refresh SPDX copyright headers across modified backend source files.