### PR TITLE
fix: catch LuceneException in document_exists [coredump-analysis]

### DIFF
--- a/src/daemon/src/core/file_index_manager.cpp
+++ b/src/daemon/src/core/file_index_manager.cpp
@@ -454,15 +454,23 @@ std::vector<std::string> file_index_manager::traverse_directory(const std::strin
 }
 
 bool file_index_manager::document_exists(const std::string &path, bool only_check_initial_index) {
-    TermPtr term = newLucene<Term>(FULL_PATH_FIELD, StringUtils::toUnicode(path));
-    TermDocsPtr termDocs;
-    if (only_check_initial_index) {
-        termDocs = reader_->termDocs(term);
-    } else {
-        try_refresh_reader(true);
-        termDocs = nrt_reader_->termDocs(term);
+    try {
+        TermPtr term = newLucene<Term>(FULL_PATH_FIELD, StringUtils::toUnicode(path));
+        TermDocsPtr termDocs;
+        if (only_check_initial_index) {
+            termDocs = reader_->termDocs(term);
+        } else {
+            try_refresh_reader(true);
+            termDocs = nrt_reader_->termDocs(term);
+        }
+        return termDocs->next();
+    } catch (const LuceneException& e) {
+        spdlog::error("Failed to check document exists {}: {}", path, StringUtils::toUTF8(e.getError()));
+    } catch (const std::exception& e) {
+        spdlog::error("Failed to check document exists {}: {}", path, e.what());
     }
-    return termDocs->next();
+
+    return false;
 }
 
 bool file_index_manager::refresh_indexes(const std::vector<std::string>& blacklist_paths, bool nrt, bool check_exist) {


### PR DESCRIPTION
## 修复：document_exists 未捕获 LuceneException 导致崩溃

### 根因

`file_index_manager::document_exists()`（`src/daemon/src/core/file_index_manager.cpp:456`）调用 `termDocs->next()` 读取索引时，索引文件损坏会抛出 `LuceneException`。该函数无 try-catch，异常传播至 `scan_directory()` → `eat_job()` → `thread_pool::thread_loop()`（均无捕获）→ `std::terminate()` → `abort()`。

同文件 `add_index()`、`remove_index()`、`update_index()` 均有 `catch(LuceneException)` + `catch(std::exception)`，唯独 `document_exists()` 遗漏。

### 修复

为 `document_exists()` 包裹 try-catch（`LuceneException` + `std::exception`），与 `add_index()` 保持一致模式；异常时记录日志并返回 false，触发上层 `init_scan` 回调的 `add_index(path)` 重建索引，实现优雅降级。

### 崩溃数据

- 聚类哈希：264c1ec875d9
- 数量：39 条（占比 3.71%）
- 主版本：7.0.38-1
- 置信度：95%（根因明确）

### 编译验证

`cmake --build . --target deepin-anything-daemon` 在 develop/eagle (e41c906) 基线上编译成功，无警告无错误。

## Summary by Sourcery

Bug Fixes:
- Prevent crashes in document_exists by catching LuceneException and std::exception during index lookup and returning a safe failure result.