### PR TITLE
fix(daemon): catch uncaught exceptions to prevent crash on corrupted index

### DIFF
--- a/src/daemon/src/core/base_event_handler.cpp
+++ b/src/daemon/src/core/base_event_handler.cpp
@@ -459,6 +459,8 @@ bool base_event_handler::scan_directory(const std::string& dir_path, std::functi
     } catch (std::filesystem::filesystem_error const& e) {
         spdlog::error("Failed to scan directory: {}, {}, {}, {}",
             e.what(), e.path1().string(), e.path2().string(), e.code().value());
+    } catch (const std::exception& e) {
+        spdlog::error("Failed to scan directory {}: {}", dir_path, e.what());
     }
 
     spdlog::info("Scanning directory {} completed", dir_path);

--- a/src/daemon/src/core/file_index_manager.cpp
+++ b/src/daemon/src/core/file_index_manager.cpp
@@ -454,15 +454,22 @@ std::vector<std::string> file_index_manager::traverse_directory(const std::strin
 }
 
 bool file_index_manager::document_exists(const std::string &path, bool only_check_initial_index) {
-    TermPtr term = newLucene<Term>(FULL_PATH_FIELD, StringUtils::toUnicode(path));
-    TermDocsPtr termDocs;
-    if (only_check_initial_index) {
-        termDocs = reader_->termDocs(term);
-    } else {
-        try_refresh_reader(true);
-        termDocs = nrt_reader_->termDocs(term);
+    try {
+        TermPtr term = newLucene<Term>(FULL_PATH_FIELD, StringUtils::toUnicode(path));
+        TermDocsPtr termDocs;
+        if (only_check_initial_index) {
+            termDocs = reader_->termDocs(term);
+        } else {
+            try_refresh_reader(true);
+            termDocs = nrt_reader_->termDocs(term);
+        }
+        return termDocs->next();
+    } catch (const LuceneException& e) {
+        spdlog::error("Failed to check document exists {}: {}", path, StringUtils::toUTF8(e.getError()));
+    } catch (const std::exception& e) {
+        spdlog::error("Failed to check document exists {}: {}", path, e.what());
     }
-    return termDocs->next();
+    return false;
 }
 
 bool file_index_manager::refresh_indexes(const std::vector<std::string>& blacklist_paths, bool nrt, bool check_exist) {

--- a/src/daemon/src/core/thread_pool.cpp
+++ b/src/daemon/src/core/thread_pool.cpp
@@ -64,7 +64,13 @@ void thread_pool::thread_loop() {
         }
 
         // do the job
-        job();
+        try {
+            job();
+        } catch (const std::exception& e) {
+            spdlog::error("Unhandled exception in thread pool job: {}", e.what());
+        } catch (...) {
+            spdlog::error("Unknown unhandled exception in thread pool job");
+        }
     }
 }
 


### PR DESCRIPTION
## 根因分析

崩溃聚类 #5（3ab00c2582df，39 例）和 #6（264c1ec875d9，26 例）同根因：`file_index_manager::document_exists()` 在索引损坏时调用 Lucene 读取接口抛出 `IOException("Read past EOF")`，异常经 `scan_directory` → `eat_job` → `thread_pool::thread_loop` 传播路径全程无捕获，逃逸线程导致 `std::terminate()` → `abort()`。

关键证据：
- `document_exists()` 无 try-catch，同文件其他函数（add_index 等）均有标准 catch 模式
- `scan_directory()` 仅 catch `filesystem_error`，无法捕获 `LuceneException`
- `thread_loop()` 中 `job()` 无 try-catch，异常逃逸点

## 修复方案

三层防御性异常捕获，不改变正常逻辑：
1. `document_exists()` — 增加 `LuceneException` + `std::exception` catch，异常时返回 false 并记录日志
2. `thread_pool::thread_loop()` — 为 `job()` 增加顶层 try-catch，防止异常逃逸线程
3. `scan_directory()` — 在 `filesystem_error` catch 后增加 `std::exception` catch

## 改动安全评估

低风险：三处均为纯防御性异常捕获，不改变函数签名、不改变正常执行路径、不影响调用者行为。

## Summary by Sourcery

Add defensive exception handling around index access and thread pool jobs to prevent daemon crashes on corrupted indexes or unexpected runtime errors.

Bug Fixes:
- Handle Lucene and standard exceptions in document existence checks to avoid crashes when the file index is corrupted.
- Prevent uncaught exceptions in thread pool jobs from terminating worker threads and crashing the daemon.
- Catch generic std::exception during directory scans to avoid scan failures propagating as hard crashes.

Enhancements:
- Improve error logging for index access, thread pool jobs, and directory scanning to aid diagnosis of runtime issues.